### PR TITLE
docs: add TypeScript remedy to 'marker icons are missing' section

### DIFF
--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -130,6 +130,16 @@ Icon.Default.mergeOptions({
 });
 ```
 
+For TypeScript, you will need to define `_getIconUrl` by hand as it is a private property:
+
+```ts
+type D = Icon.Default & {
+  _getIconUrl: string;
+};
+
+delete (Icon.Default.prototype as D)._getIconUrl;
+```
+
 ## Accessing `leaflet` api
 
 Leaflet inner methods and properties can always be accessed by the `mapObject` attribute, to do so a simple ref is necessary:


### PR DESCRIPTION
Resolves #543