### PR TITLE
Offer option for disable scroll propagation in control

### DIFF
--- a/docs/components/LControl.md
+++ b/docs/components/LControl.md
@@ -50,11 +50,12 @@ export default {
 
 ## Props
 
-| Prop name               | Description | Type    | Values | Default    |
-| ----------------------- | ----------- | ------- | ------ | ---------- |
-| position                |             | string  | -      | 'topright' |
-| options                 |             | object  | -      | {}         |
-| disableClickPropagation |             | boolean | -      | true       |
+| Prop name                | Description | Type    | Values | Default    |
+| ------------------------ | ----------- | ------- | ------ | ---------- |
+| position                 |             | string  | -      | 'topright' |
+| options                  |             | object  | -      | {}         |
+| disableClickPropagation  |             | boolean | -      | true       |
+| disableScrollPropagation |             | boolean | -      | false      |
 
 ## Events
 

--- a/src/components/LControl.vue
+++ b/src/components/LControl.vue
@@ -22,6 +22,11 @@ export default {
       custom: true,
       default: true,
     },
+    disableScrollPropagation: {
+      type: Boolean,
+      custom: true,
+      default: false,
+    }
   },
   mounted() {
     const LControl = Control.extend({
@@ -40,6 +45,9 @@ export default {
     this.mapObject.setElement(this.$el);
     if (this.disableClickPropagation) {
       DomEvent.disableClickPropagation(this.$el);
+    }
+    if (this.disableScrollPropagation) {
+      DomEvent.disableScrollPropagation(this.$el);
     }
     this.mapObject.addTo(this.parentContainer.mapObject);
     this.$nextTick(() => {

--- a/tests/unit/components/LControl.spec.js
+++ b/tests/unit/components/LControl.spec.js
@@ -47,4 +47,26 @@ describe('component: LControl.vue', () => {
     }
     expect(mapWrapper.vm.mapObject.getZoom()).toEqual(initZoom + triggerCount);
   });
+
+  test('LControl.vue enable scroll propagation by default', () => {
+    const triggerCount = 3;
+    const { wrapper, mapWrapper } = getWrapperWithMap(LControl);
+    const initZoom = mapWrapper.vm.mapObject.getZoom();
+    for (let i = 0; i < triggerCount; ++i) {
+      wrapper.trigger('scroll');
+    }
+    expect(mapWrapper.vm.mapObject.getZoom()).toEqual(initZoom);
+  });
+
+  test('LControl.vue disable scroll propagation', () => {
+    const triggerCount = 3;
+    const { wrapper, mapWrapper } = getWrapperWithMap(LControl, {
+      disableScrollPropagation: true
+    });
+    const initZoom = mapWrapper.vm.mapObject.getZoom();
+    for (let i = 0; i < triggerCount; ++i) {
+      wrapper.trigger('scroll');
+    }
+    expect(mapWrapper.vm.mapObject.getZoom()).toEqual(initZoom);
+  });
 });


### PR DESCRIPTION
IMO this prop should be `true` by default. For backward compatibility, I set it to false. I left you a message in the Discord if you have any feedback for me.