### PR TITLE
map options override prop defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ Inspired by many map wrapper (google and leaflet) for many framework (React, Ang
     <td align="center"><a href="https://github.com/udos"><img src="https://avatars3.githubusercontent.com/u/141107?v=4" width="100px;" alt=""/><br /><sub><b>Udo Schochtert</b></sub></a><br /><a href="https://github.com/vue-leaflet/Vue2Leaflet/issues?q=author%3Audos" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://github.com/maratumba"><img src="https://avatars2.githubusercontent.com/u/2898911?v=4" width="100px;" alt=""/><br /><sub><b>Yaman Ozakin</b></sub></a><br /><a href="https://github.com/vue-leaflet/Vue2Leaflet/issues?q=author%3Amaratumba" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://terra-azure.org"><img src="https://avatars0.githubusercontent.com/u/682269?v=4" width="100px;" alt=""/><br /><sub><b>Andre-John Mas</b></sub></a><br /><a href="https://github.com/vue-leaflet/Vue2Leaflet/commits?author=ajmas" title="Documentation">📖</a> <a href="https://github.com/vue-leaflet/Vue2Leaflet/commits?author=ajmas" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/geopic"><img src="https://avatars0.githubusercontent.com/u/29524044?v=4" width="100px;" alt=""/><br /><sub><b>George Pickering</b></sub></a><br /><a href="https://github.com/vue-leaflet/Vue2Leaflet/commits?author=geopic" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://github.com/Machine-Maker"><img src="https://avatars2.githubusercontent.com/u/15055071?v=4" width="100px;" alt="" /><br /><sub><b>Machine Maker</b></sub></a><br /><a href="https://github.com/vue-leaflet/Vue2Leaflet/commits?author=Machine-Maker" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Vue2Leaflet
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-12-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <img src="https://github.com/vue-leaflet/Vue2Leaflet/workflows/Test%20Action/badge.svg?branch=master" alt="ci">
@@ -62,7 +65,6 @@ This will reduce the size of the bundle significantly
 
 Do you have questions? Ideas? do you want to collaborate but you feel lost? Join us on discord [Invite Link](https://discord.gg/uVZAfUf)
 
-
 ## Leaflet Plugins
 
 Vue2Leaflet has a wide array of plugins written by the community! [Check Here](https://vue2-leaflet.netlify.com/plugins/)
@@ -91,6 +93,7 @@ Any changes to the source code is reflected in the docs after a handfuls of seco
 Inspired by many map wrapper (google and leaflet) for many framework (React, Angular and Vue 1.0)
 
 ## Contributors
+
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
@@ -110,13 +113,14 @@ Inspired by many map wrapper (google and leaflet) for many framework (React, Ang
     <td align="center"><a href="https://github.com/maratumba"><img src="https://avatars2.githubusercontent.com/u/2898911?v=4" width="100px;" alt=""/><br /><sub><b>Yaman Ozakin</b></sub></a><br /><a href="https://github.com/vue-leaflet/Vue2Leaflet/issues?q=author%3Amaratumba" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://terra-azure.org"><img src="https://avatars0.githubusercontent.com/u/682269?v=4" width="100px;" alt=""/><br /><sub><b>Andre-John Mas</b></sub></a><br /><a href="https://github.com/vue-leaflet/Vue2Leaflet/commits?author=ajmas" title="Documentation">📖</a> <a href="https://github.com/vue-leaflet/Vue2Leaflet/commits?author=ajmas" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/geopic"><img src="https://avatars0.githubusercontent.com/u/29524044?v=4" width="100px;" alt=""/><br /><sub><b>George Pickering</b></sub></a><br /><a href="https://github.com/vue-leaflet/Vue2Leaflet/commits?author=geopic" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/Machine-Maker"><img src="https://avatars2.githubusercontent.com/u/15055071?v=4" width="100px;" alt="" /><br /><sub><b>Machine Maker</b></sub></a><br /><a href="https://github.com/vue-leaflet/Vue2Leaflet/commits?author=Machine-Maker" title="Code">💻</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
-<!-- ALL-CONTRIBUTORS-LIST:END -->
 
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
 > If you believe you should be on this list please add yourself by typing this on a PR or issue: `@all-contributors please add @yourNickname for X` where X is one of [all-contributors emojoi keys](https://allcontributors.org/docs/en/emoji-key)
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -87,13 +87,8 @@ export const optionsMerger = (props, instance) => {
     const def = defaultProps[key]
       ? defaultProps[key].default
       : Symbol('unique');
-    if (result[key] && def !== props[key]) {
-      console.warn(
-        `${key} props is overriding the value passed in the options props`
-      );
-      result[key] = props[key];
-    } else if (!result[key]) {
-      result[key] = props[key];
+    if (!result[key]) {
+      result[key] = props[key] || def;
     }
   }
   return result;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -85,10 +85,24 @@ export const optionsMerger = (props, instance) => {
   const defaultProps = instance.$options.props;
   for (const key in props) {
     const def = defaultProps[key]
-      ? defaultProps[key].default
+      ? defaultProps[key].default &&
+        typeof defaultProps[key].default === 'function'
+        ? defaultProps[key].default.call()
+        : defaultProps[key].default
       : Symbol('unique');
-    if (!result[key]) {
-      result[key] = props[key] || def;
+    let isEqual = false;
+    if (Array.isArray(def)) {
+      isEqual = JSON.stringify(def) === JSON.stringify(props[key]);
+    } else {
+      isEqual = def === props[key];
+    }
+    if (result[key] && !isEqual) {
+      console.warn(
+        `${key} props is overriding the value passed in the options props`
+      );
+      result[key] = props[key];
+    } else if (!result[key]) {
+      result[key] = props[key];
     }
   }
   return result;

--- a/tests/unit/components/LMap.spec.js
+++ b/tests/unit/components/LMap.spec.js
@@ -262,4 +262,38 @@ describe('component: LMap.vue', () => {
       }
     });
   });
+
+  test('LMap.vue options.prop should override default prop value', () => {
+    const options = {
+      center: [100,100],
+      crs: L.CRS.Simple
+    }
+    const wrapper = getMapWrapper(options)
+
+    expect(wrapper.exists()).toBe(true);
+
+    expect(wrapper.vm.center).toBe(options.center)
+    expect(wrapper.vm.crs).toBe(options.crs)
+  })
+
+  test('LMap.vue if prop is not default, it should override options.prop', () => {
+    const options = {
+      center: [100, 100],
+      crs: L.CRS.EPSG3395
+    }
+
+    const props = {
+      center: [-100, -100],
+      crs: L.CRS.Simple
+    }
+
+    const wrapper = getMapWrapper(options)
+
+    wrapper.setProps(props)
+
+    expect(wrapper.exists()).toBe(true)
+
+    expect(wrapper.vm.center).toBe(props.center)
+    expect(wrapper.vm.crs).toBe(props.crs)
+  })
 });


### PR DESCRIPTION
I was noticing that if I put all my map options into one object, and passed that to the LMap component, the default value for the crs, center, and other props would override the value from the options object. That probably shouldn't work that way, a default overriding a set value. This should fix that.