### PR TITLE
Added to docs an alternative API access method via LMap  `ready` event

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -45,6 +45,19 @@ mounted () {
 
 This also work for any other component (Marker, Polyline, etc...)
 
+**Note:** If you're having troubles using `mounted` hook, you can use [l-map](/components/LMap.md) component `ready` event to ensure that you access `mapObject` after it's loaded:
+
+```html
+<l-map ref="map" @ready="doSomethingOnReady()"></l-map>
+```
+```javascript
+methods: {
+    doSomethingOnReady() {
+        this.map = this.$refs.map.mapObject
+    },
+},
+```
+
 ## How can I bind events of Vue2Leaflet components?
 
 All event binding can be done to event with the same name as in [leaflet documentation](http://leafletjs.com/reference-1.3.0.html).

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -163,3 +163,17 @@ Leaflet inner methods and properties can always be accessed by the `mapObject` a
 ::: tip
 `mapObject` is not going to be available immediately that is why `$nextTick` method is used.
 :::
+
+
+**Note:** You can also use [l-map](/components/LMap.md) component `ready` event to ensure that you access `mapObject` after it's loaded:
+
+```html
+<l-map ref="myMap" @ready="doSomethingOnReady()"></l-map>
+```
+```javascript
+methods: {
+    doSomethingOnReady() {
+        this.map = this.$refs.myMap.mapObject
+    },
+},
+```


### PR DESCRIPTION
In some cases accessing API via `mounted` `$nextTick` hook doesn't work, as `mapObject` is still not ready (`undefined`). See:
https://github.com/vue-leaflet/Vue2Leaflet/issues/433
At least when using Nuxt.

So, to save people some debugging time I've added to the docs another API access method via `LMap` `ready` event to QuickStart and FAQ sections.

I do not know the reasoning for using mounted() hook if favour of `ready` event. So I've added this information as a note after it.