### PR TITLE
Tile layer accepts both string and string[] for the subdomains prop

### DIFF
--- a/src/mixins/TileLayer.js
+++ b/src/mixins/TileLayer.js
@@ -5,26 +5,34 @@ export default {
   props: {
     tms: {
       type: Boolean,
-      default: false
+      default: false,
     },
     subdomains: {
-      type: String,
-      default: 'abc'
+      type: [String, Array],
+      default: 'abc',
+      validator: prop => {
+        if (typeof prop === 'string') return true;
+        // Validates array that array only contains only strings
+        if (Array.isArray(prop)) {
+          return prop.every(subdomain => typeof subdomain === 'string');
+        }
+        return false;
+      },
     },
     detectRetina: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
-  mounted () {
+  mounted() {
     this.tileLayerOptions = {
       ...this.gridLayerOptions,
       tms: this.tms,
       subdomains: this.subdomains,
-      detectRetina: this.detectRetina
+      detectRetina: this.detectRetina,
     };
   },
-  render () {
+  render() {
     return null;
-  }
+  },
 };


### PR DESCRIPTION
Fixes #598 