### PR TITLE
Fix #564: Allow Leaflet latLngBounds objects to be passed to LRectangle bounds prop

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,9 @@ module.exports = {
   setupFiles: [
     '<rootDir>/tests/setup.js'
   ],
+  setupFilesAfterEnv: [
+    "jest-mock-console/dist/setupTestFramework.js",
+  ],
   transform: {
     '^.+\\.vue$': 'vue-jest',
     '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$':

--- a/package-lock.json
+++ b/package-lock.json
@@ -9628,6 +9628,12 @@
         "@jest/types": "^24.9.0"
       }
     },
+    "jest-mock-console": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jest-mock-console/-/jest-mock-console-1.0.1.tgz",
+      "integrity": "sha512-Bn+Of/cvz9LOEEeEg5IX5Lsf8D2BscXa3Zl5+vSVJl37yiT8gMAPPKfE09jJOwwu1zbagL11QTrH+L/Gn8udOg==",
+      "dev": true
+    },
     "jest-pnp-resolver": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-vue": "^6.1.2",
     "husky": "^3.1.0",
     "jest": "^24.9.0",
+    "jest-mock-console": "^1.0.1",
     "jest-serializer-vue": "^2.0.2",
     "jest-transform-stub": "^2.0.0",
     "leaflet": "^1.6.0",

--- a/src/components/LRectangle.vue
+++ b/src/components/LRectangle.vue
@@ -8,7 +8,7 @@
 import { optionsMerger, propsBinder, findRealParent } from '../utils/utils.js';
 import Polygon from '../mixins/Polygon.js';
 import Options from '../mixins/Options.js';
-import { rectangle, DomEvent } from 'leaflet';
+import { rectangle, latLngBounds, DomEvent } from 'leaflet';
 
 /**
  * Easily draw a rectangle on the map
@@ -18,8 +18,8 @@ export default {
   mixins: [Polygon, Options],
   props: {
     bounds: {
-      type: Array,
-      default: () => [],
+      default: () => [[0,0],[0,0]],
+      validator: value => value && latLngBounds(value).isValid(),
     },
   },
   data() {

--- a/tests/unit/components/LRectangle.spec.js
+++ b/tests/unit/components/LRectangle.spec.js
@@ -1,0 +1,36 @@
+import mockConsole from "jest-mock-console";
+import { getWrapperWithMap } from '@/tests/test-helpers';
+import LRectangle from '@/components/LRectangle.vue';
+import { latLngBounds } from 'leaflet';
+
+describe('component: LRectangle.vue', () => {
+  beforeEach(() => {
+    mockConsole();
+  });
+
+  test('it has a mapObject', () => {
+    const { wrapper } = getWrapperWithMap(LRectangle);
+
+    expect(console.error).not.toHaveBeenCalled()
+    expect(wrapper.vm.mapObject).toBeDefined();
+  });
+
+  test('it accepts a valid pair of coordinates as its bounds', () => {
+    const bounds = [[1.2, 2.3], [3.4, 4.5]];
+
+    const { wrapper } = getWrapperWithMap(LRectangle, { bounds });
+
+    expect(console.error).not.toHaveBeenCalled()
+    expect(wrapper.vm.mapObject).toBeInstanceOf(L.Rectangle);
+  });
+
+  test('it accepts valid Leaflet LatLngBounds as its bounds', () => {
+    const bounds = latLngBounds([1.2, 2.3], [3.4, 4.5]);
+
+    const { wrapper } = getWrapperWithMap(LRectangle, { bounds });
+
+    expect(console.error).not.toHaveBeenCalled()
+    expect(wrapper.vm.mapObject).toBeInstanceOf(L.Rectangle);
+  });
+
+});


### PR DESCRIPTION
Adds a validator and default value to the LRectangle component, allowing any value that Leaflet can convert to a valid `latLngBounds` object to pass props validation.

Also adds a very small set of tests for LRectangle, verifying the new behaviour.