### PR TITLE
Fix #614: Set "last set" cached center and bounds to initial values in LMap data

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -145,8 +145,8 @@ export default {
   data() {
     return {
       ready: false,
-      lastSetCenter: null,
-      lastSetBounds: null,
+      lastSetCenter: this.center ? latLng(this.center) : null,
+      lastSetBounds: this.bounds ? latLngBounds(this.bounds) : null,
       lastSetZoom: null,
       layerControl: undefined,
       layersToAdd: [],

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -198,7 +198,6 @@ export default {
       this
     );
     this.mapObject = map(this.$el, options);
-    this.setBounds(this.bounds);
     this.mapObject.on('moveend', debounce(this.moveEndHandler, 100));
     this.mapObject.on('overlayadd', this.overlayAddHandler);
     this.mapObject.on('overlayremove', this.overlayRemoveHandler);

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -147,7 +147,6 @@ export default {
       ready: false,
       lastSetCenter: this.center ? latLng(this.center) : null,
       lastSetBounds: this.bounds ? latLngBounds(this.bounds) : null,
-      lastSetZoom: null,
       layerControl: undefined,
       layersToAdd: [],
       layersInControl: [],

--- a/tests/unit/components/LMap.spec.js
+++ b/tests/unit/components/LMap.spec.js
@@ -79,16 +79,6 @@ describe('component: LMap.vue', () => {
     const bounds = L.latLngBounds(L.latLng([1, 1]), L.latLng([2, 2]));
     const newBounds = [[4, 4], [5, 5]];
     const newBounds2 = L.latLngBounds(L.latLng([10, 10]), L.latLng([20, 20]));
-    const defaultOptions = {
-      animate: null,
-      pan: {
-        animate: null,
-        duration: undefined
-      },
-      zoom: {
-        animate: null
-      }
-    };
 
     const mockFitBounds = jest.fn();
     const wrapper = getMapWrapper({ bounds: bounds });
@@ -101,9 +91,7 @@ describe('component: LMap.vue', () => {
 
     expect(mockFitBounds.mock.calls.length).toBe(2);
     expect(mockFitBounds.mock.calls[0][0]).toEqual(L.latLngBounds(newBounds));
-    expect(mockFitBounds.mock.calls[0][1]).toEqual(defaultOptions);
     expect(mockFitBounds.mock.calls[1][0]).toEqual(L.latLngBounds(newBounds2));
-    expect(mockFitBounds.mock.calls[1][1]).toEqual(defaultOptions);
   });
 
   test('LMap.vue with same bounds', async () => {
@@ -240,60 +228,42 @@ describe('component: LMap.vue', () => {
 
     expect(mockFitBounds.mock.calls.length).toBe(2);
     expect(mockFitBounds.mock.calls[0][0]).toEqual(L.latLngBounds(newBounds));
-    expect(mockFitBounds.mock.calls[0][1]).toEqual({
-      animate: false,
-      pan: {
-        animate: false,
-        duration: undefined
-      },
-      zoom: {
-        animate: false
-      }
-    });
+    expect(mockFitBounds.mock.calls[0][1]).toMatchObject({ animate: false });
     expect(mockFitBounds.mock.calls[1][0]).toEqual(L.latLngBounds(newBounds2));
-    expect(mockFitBounds.mock.calls[1][1]).toEqual({
-      animate: false,
-      pan: {
-        animate: false,
-        duration: undefined
-      },
-      zoom: {
-        animate: false
-      }
-    });
+    expect(mockFitBounds.mock.calls[1][1]).toMatchObject({ animate: false });
   });
 
   test('LMap.vue options.prop should override default prop value', () => {
     const options = {
       center: [100,100],
       crs: L.CRS.Simple
-    }
-    const wrapper = getMapWrapper(options)
+    };
+    const wrapper = getMapWrapper(options);
 
     expect(wrapper.exists()).toBe(true);
 
-    expect(wrapper.vm.center).toBe(options.center)
-    expect(wrapper.vm.crs).toBe(options.crs)
-  })
+    expect(wrapper.vm.center).toBe(options.center);
+    expect(wrapper.vm.crs).toBe(options.crs);
+  });
 
   test('LMap.vue if prop is not default, it should override options.prop', () => {
     const options = {
       center: [100, 100],
       crs: L.CRS.EPSG3395
-    }
+    };
 
     const props = {
       center: [-100, -100],
       crs: L.CRS.Simple
-    }
+    };
 
-    const wrapper = getMapWrapper(options)
+    const wrapper = getMapWrapper(options);
 
-    wrapper.setProps(props)
+    wrapper.setProps(props);
 
-    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.exists()).toBe(true);
 
-    expect(wrapper.vm.center).toBe(props.center)
-    expect(wrapper.vm.crs).toBe(props.crs)
-  })
+    expect(wrapper.vm.center).toBe(props.center);
+    expect(wrapper.vm.crs).toBe(props.crs);
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -555,7 +555,6 @@ declare module "vue2-leaflet" {
     ready: boolean;
     lastSetCenter: L.LatLng | null;
     lastSetBounds: L.Bounds | null;
-    lastSetZoom: number | null;
     layerControl?: any;
     layersToAdd: any[];
     mapObject: L.Map;


### PR DESCRIPTION
This resolves #614 by ensuring that if something triggers `setCenter` or `setBounds` for the first time with a new value equal to the initial value provided through `props`, the map view is not affected.

The specific instance reported in the issue was happening because the centre of the map was being bound to a hard coded array in the template, `<l-map :center="[51, -114]">`. This meant that somewhere in the Vue internals, the watch set up by `propsBinder` was being triggered when an update to the map caused the value of `center` to be (re)set to _a different instance_ of the same array, `[51, -114]`.

This in turn caused `setCenter` to be called, which saw that the `lastSetCenter` was `null` and so instead used the current map centre. But that meant that if the map had been panned, the initial centre would be different from the "last" one, so the map would—bizarrely—pan back to its initial centre.

---

There wasn't a bug report associated it with, but I updated the `bounds` / `setBounds` / `lastSetBounds` combination to mirror this fix. I also removed the `data` property `lastSetZoom`, because it wasn't used anywhere else in the code base.