### PR TITLE
Fix #617: Tie both `bounds` and `center`/`zoom` changes to single cached map view state

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -273,6 +273,7 @@ export default {
       this.mapObject.setZoom(newVal, {
         animate: this.noBlockingAnimations ? false : null,
       });
+      this.cacheMapView();
     },
     setCenter(newVal, oldVal) {
       if (newVal == null) {
@@ -285,6 +286,7 @@ export default {
         this.mapObject.panTo(newCenter, {
           animate: this.noBlockingAnimations ? false : null,
         });
+        this.cacheMapView(undefined, newCenter);
       }
     },
     setBounds(newVal, oldVal) {
@@ -298,8 +300,8 @@ export default {
       const oldBounds = this.lastSetBounds || this.mapObject.getBounds();
       const boundsChanged = !oldBounds.equals(newBounds, 0); // set maxMargin to 0 - check exact equals
       if (boundsChanged) {
-        this.lastSetBounds = newBounds;
         this.mapObject.fitBounds(newBounds, this.fitBoundsOptions);
+        this.cacheMapView(newBounds);
       }
     },
     setPaddingBottomRight(newVal, oldVal) {
@@ -352,6 +354,11 @@ export default {
       if (layer) {
         layer.updateVisibleProp(false);
       }
+    },
+    cacheMapView(bounds, center) {
+      // Cache the last values used to define the map view by mutating props.
+      this.lastSetBounds = bounds || this.mapObject.getBounds();
+      this.lastSetCenter = center || this.lastSetBounds.getCenter();
     },
   },
 };

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -269,7 +269,7 @@ export default {
       }
     },
     setZoom(newVal, oldVal) {
-      if (!newVal) { return; }
+      if (newVal === undefined || newVal === null) { return; }
       this.mapObject.setZoom(newVal, {
         animate: this.noBlockingAnimations ? false : null,
       });

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -198,6 +198,9 @@ export default {
       this
     );
     this.mapObject = map(this.$el, options);
+    if (this.bounds) {
+      this.mapObject.fitBounds(this.bounds);
+    }
     this.mapObject.on('moveend', debounce(this.moveEndHandler, 100));
     this.mapObject.on('overlayadd', this.overlayAddHandler);
     this.mapObject.on('overlayremove', this.overlayRemoveHandler);

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -266,6 +266,7 @@ export default {
       }
     },
     setZoom(newVal, oldVal) {
+      if (!newVal) { return; }
       this.mapObject.setZoom(newVal, {
         animate: this.noBlockingAnimations ? false : null,
       });


### PR DESCRIPTION
The problems described in #617 stem largely from the fact that previously, the following steps could take place:

1. Set the `bounds` prop to a particular value.
    * This caches the bounds.
2. Set the `center` and/or `zoom` props to something that changes the map view.
    * This caches the centre.
3. Set the `bounds` prop back to the _same value_ as in step 1.
    * This _should_ change the map view based on the new bounds.
    * Instead, because the new bounds are the same as the previously cached ones, _nothing happens_.

Add to this the fact that there was no way to simply unset the zoom level that wouldn't default it to 0, and the result was the unexpected "chaos" described in the issue.

---

Removing the default value on `LMap.zoom` would change the public API so I didn't do that, but I did add a check in `setZoom` for `null`, which allows a way to unset the current value without triggering a zoom change on the map. @DonNicoJs I wasn't sure if this was the sort of thing worth noting in the docs, or if so where it would best appear. Let me know if you'd like me to add that!