### PR TITLE
624: Add support for the `scrollWheelZoom` map option.

### DIFF
--- a/docs/components/LMap.md
+++ b/docs/components/LMap.md
@@ -70,30 +70,31 @@ export default {
 
 ## Props
 
-| Prop name              | Description                                    | Type          | Values         | Default            |
-| ---------------------- | ---------------------------------------------- | ------------- | -------------- | ------------------ |
-| options                |                                                | object        | -              | {}                 |
-| center                 | The center of the map, supports .sync modifier | object\|array | -              | () => [0, 0]       |
-| bounds                 | The bounds of the map, supports .sync modifier | array\|object | -              | null               |
-| maxBounds              | The max bounds of the map                      | array\|object | -              | null               |
-| zoom                   | The zoom of the map, supports .sync modifier   | number        | -              | 0                  |
-| minZoom                | The minZoom of the map                         | number        | -              | null               |
-| maxZoom                | The maxZoom of the map                         | number        | -              | null               |
-| paddingBottomRight     | The paddingBottomRight of the map              | array         | -              | null               |
-| paddingTopLeft         | The paddingTopLeft of the map                  | array         | -              | null               |
-| padding                | The padding of the map                         | array         | -              | null               |
-| worldCopyJump          | The worldCopyJump option for the map           | boolean       | -              | false              |
-| crs                    | The crs option for the map                     | object        | `CRS.EPSG3857` | () => CRS.EPSG3857 |
-| maxBoundsViscosity     |                                                | number        | -              | null               |
-| inertia                |                                                | boolean       | -              | null               |
-| inertiaDeceleration    |                                                | number        | -              | null               |
-| inertiaMaxSpeed        |                                                | number        | -              | null               |
-| easeLinearity          |                                                | number        | -              | null               |
-| zoomAnimation          |                                                | boolean       | -              | null               |
-| zoomAnimationThreshold |                                                | number        | -              | null               |
-| fadeAnimation          |                                                | boolean       | -              | null               |
-| markerZoomAnimation    |                                                | boolean       | -              | null               |
-| noBlockingAnimations   |                                                | boolean       | -              | false              |
+| Prop name              | Description                                    | Type            | Values         | Default            |
+| ---------------------- | ---------------------------------------------- | --------------- | -------------- | ------------------ |
+| options                |                                                | object          | -              | {}                 |
+| center                 | The center of the map, supports .sync modifier | object\|array   | -              | () => [0, 0]       |
+| bounds                 | The bounds of the map, supports .sync modifier | array\|object   | -              | null               |
+| maxBounds              | The max bounds of the map                      | array\|object   | -              | null               |
+| zoom                   | The zoom of the map, supports .sync modifier   | number          | -              | 0                  |
+| minZoom                | The minZoom of the map                         | number          | -              | null               |
+| maxZoom                | The maxZoom of the map                         | number          | -              | null               |
+| paddingBottomRight     | The paddingBottomRight of the map              | array           | -              | null               |
+| paddingTopLeft         | The paddingTopLeft of the map                  | array           | -              | null               |
+| padding                | The padding of the map                         | array           | -              | null               |
+| worldCopyJump          | The worldCopyJump option for the map           | boolean         | -              | false              |
+| crs                    | The crs option for the map                     | object          | `CRS.EPSG3857` | () => CRS.EPSG3857 |
+| maxBoundsViscosity     |                                                | number          | -              | null               |
+| inertia                |                                                | boolean         | -              | null               |
+| inertiaDeceleration    |                                                | number          | -              | null               |
+| inertiaMaxSpeed        |                                                | number          | -              | null               |
+| easeLinearity          |                                                | number          | -              | null               |
+| zoomAnimation          |                                                | boolean         | -              | null               |
+| zoomAnimationThreshold |                                                | number          | -              | null               |
+| fadeAnimation          |                                                | boolean         | -              | null               |
+| markerZoomAnimation    |                                                | boolean         | -              | null               |
+| noBlockingAnimations   |                                                | boolean         | -              | false              |
+| scrollWheelZoom        | The scrollWheelZoom option for the map         | boolean\|string | -              | false              |
 
 ## Events
 

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -141,6 +141,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    scrollWheelZoom: {
+      type: [ Boolean, String ],
+      default: true,
+    },
   },
   data() {
     return {
@@ -194,6 +198,7 @@ export default {
         zoomAnimationThreshold: this.zoomAnimationThreshold,
         fadeAnimation: this.fadeAnimation,
         markerZoomAnimation: this.markerZoomAnimation,
+        scrollWheelZoom: this.scrollWheelZoom,
       },
       this
     );


### PR DESCRIPTION
This PR adds support for the scrollWhellZoom option from leaflet (https://leafletjs.com/reference-1.7.1.html).

You can use it by simply binding the scroll-wheel-zoom attribute, like so: `<l-map :scroll-wheel-zoom="false" ...>`.
The allowed values are:

- true (default): Allow scroll wheel zoom
- false: Disable scroll wheel zoom
- 'center': Zoom to the center of the view regardless of where the mouse was

The apparently big change in the markdown table in the docs is because I had to reformat the whole table because `boolean\|string` was longer than the previously longest value. All I really added was the last line in the table.