### PR TITLE
Resolve 624

### DIFF
--- a/docs/components/LCircle.md
+++ b/docs/components/LCircle.md
@@ -51,32 +51,32 @@ export default {
 
 ## Props
 
-| Prop name           | Description | Type          | Values | Default       |
-| ------------------- | ----------- | ------------- | ------ | ------------- |
-| pane                |             | string        | -      | 'overlayPane' |
-| attribution         |             | string        | -      | null          |
-| name                |             | string        | -      | undefined     |
-| layerType           |             | string        | -      | undefined     |
-| visible             |             | boolean       | -      | true          |
-| interactive         |             | boolean       | -      | true          |
-| bubblingMouseEvents |             | boolean       | -      | true          |
-| lStyle              |             | object        | -      | null          |
-| stroke              |             | boolean       | -      | true          |
-| color               |             | string        | -      | '#3388ff'     |
-| weight              |             | number        | -      | 3             |
-| opacity             |             | number        | -      | 1.0           |
-| lineCap             |             | string        | -      | 'round'       |
-| lineJoin            |             | string        | -      | 'round'       |
-| dashArray           |             | string        | -      | null          |
-| dashOffset          |             | string        | -      | null          |
-| fill                |             | boolean       | -      | true          |
-| fillColor           |             | string        | -      | '#3388ff'     |
-| fillOpacity         |             | number        | -      | 0.2           |
-| fillRule            |             | string        | -      | 'evenodd'     |
-| className           |             | string        | -      | null          |
-| radius              |             | number        | -      | null          |
-| options             |             | object        | -      | {}            |
-| latLng              |             | object\|array | -      | () => [0, 0]  |
+| Prop name           | Description                                          | Type          | Values | Default       |
+| ------------------- | ---------------------------------------------------- | ------------- | ------ | ------------- |
+| pane                |                                                      | string        | -      | 'overlayPane' |
+| attribution         |                                                      | string        | -      | null          |
+| name                |                                                      | string        | -      | undefined     |
+| layerType           |                                                      | string        | -      | undefined     |
+| visible             |                                                      | boolean       | -      | true          |
+| interactive         |                                                      | boolean       | -      | true          |
+| bubblingMouseEvents |                                                      | boolean       | -      | true          |
+| lStyle              |                                                      | object        | -      | null          |
+| stroke              |                                                      | boolean       | -      | true          |
+| color               |                                                      | string        | -      | '#3388ff'     |
+| weight              |                                                      | number        | -      | 3             |
+| opacity             |                                                      | number        | -      | 1.0           |
+| lineCap             |                                                      | string        | -      | 'round'       |
+| lineJoin            |                                                      | string        | -      | 'round'       |
+| dashArray           |                                                      | string        | -      | null          |
+| dashOffset          |                                                      | string        | -      | null          |
+| fill                |                                                      | boolean       | -      | true          |
+| fillColor           |                                                      | string        | -      | '#3388ff'     |
+| fillOpacity         |                                                      | number        | -      | 0.2           |
+| fillRule            |                                                      | string        | -      | 'evenodd'     |
+| className           |                                                      | string        | -      | null          |
+| radius              |                                                      | number        | -      | null          |
+| options             | Leaflet options to pass to the component constructor | object        | -      | {}            |
+| latLng              |                                                      | object\|array | -      | () => [0, 0]  |
 
 ## Events
 

--- a/docs/components/LCircleMarker.md
+++ b/docs/components/LCircleMarker.md
@@ -50,32 +50,32 @@ export default {
 
 ## Props
 
-| Prop name           | Description | Type          | Values | Default      |
-| ------------------- | ----------- | ------------- | ------ | ------------ |
-| pane                |             | string        | -      | 'markerPane' |
-| attribution         |             | string        | -      | null         |
-| name                |             | string        | -      | undefined    |
-| layerType           |             | string        | -      | undefined    |
-| visible             |             | boolean       | -      | true         |
-| interactive         |             | boolean       | -      | true         |
-| bubblingMouseEvents |             | boolean       | -      | true         |
-| lStyle              |             | object        | -      | null         |
-| stroke              |             | boolean       | -      | true         |
-| color               |             | string        | -      | '#3388ff'    |
-| weight              |             | number        | -      | 3            |
-| opacity             |             | number        | -      | 1.0          |
-| lineCap             |             | string        | -      | 'round'      |
-| lineJoin            |             | string        | -      | 'round'      |
-| dashArray           |             | string        | -      | null         |
-| dashOffset          |             | string        | -      | null         |
-| fill                |             | boolean       | -      | true         |
-| fillColor           |             | string        | -      | '#3388ff'    |
-| fillOpacity         |             | number        | -      | 0.2          |
-| fillRule            |             | string        | -      | 'evenodd'    |
-| className           |             | string        | -      | null         |
-| radius              |             | number        | -      | null         |
-| options             |             | object        | -      | {}           |
-| latLng              |             | object\|array | -      | () => [0, 0] |
+| Prop name           | Description                                          | Type          | Values | Default      |
+| ------------------- | ---------------------------------------------------- | ------------- | ------ | ------------ |
+| pane                |                                                      | string        | -      | 'markerPane' |
+| attribution         |                                                      | string        | -      | null         |
+| name                |                                                      | string        | -      | undefined    |
+| layerType           |                                                      | string        | -      | undefined    |
+| visible             |                                                      | boolean       | -      | true         |
+| interactive         |                                                      | boolean       | -      | true         |
+| bubblingMouseEvents |                                                      | boolean       | -      | true         |
+| lStyle              |                                                      | object        | -      | null         |
+| stroke              |                                                      | boolean       | -      | true         |
+| color               |                                                      | string        | -      | '#3388ff'    |
+| weight              |                                                      | number        | -      | 3            |
+| opacity             |                                                      | number        | -      | 1.0          |
+| lineCap             |                                                      | string        | -      | 'round'      |
+| lineJoin            |                                                      | string        | -      | 'round'      |
+| dashArray           |                                                      | string        | -      | null         |
+| dashOffset          |                                                      | string        | -      | null         |
+| fill                |                                                      | boolean       | -      | true         |
+| fillColor           |                                                      | string        | -      | '#3388ff'    |
+| fillOpacity         |                                                      | number        | -      | 0.2          |
+| fillRule            |                                                      | string        | -      | 'evenodd'    |
+| className           |                                                      | string        | -      | null         |
+| radius              |                                                      | number        | -      | null         |
+| options             | Leaflet options to pass to the component constructor | object        | -      | {}           |
+| latLng              |                                                      | object\|array | -      | () => [0, 0] |
 
 ## Events
 

--- a/docs/components/LControl.md
+++ b/docs/components/LControl.md
@@ -50,12 +50,12 @@ export default {
 
 ## Props
 
-| Prop name                | Description | Type    | Values | Default    |
-| ------------------------ | ----------- | ------- | ------ | ---------- |
-| position                 |             | string  | -      | 'topright' |
-| options                  |             | object  | -      | {}         |
-| disableClickPropagation  |             | boolean | -      | true       |
-| disableScrollPropagation |             | boolean | -      | false      |
+| Prop name                | Description                                          | Type    | Values | Default    |
+| ------------------------ | ---------------------------------------------------- | ------- | ------ | ---------- |
+| position                 |                                                      | string  | -      | 'topright' |
+| options                  | Leaflet options to pass to the component constructor | object  | -      | {}         |
+| disableClickPropagation  |                                                      | boolean | -      | true       |
+| disableScrollPropagation |                                                      | boolean | -      | false      |
 
 ## Events
 

--- a/docs/components/LControlAttribution.md
+++ b/docs/components/LControlAttribution.md
@@ -41,11 +41,11 @@ export default {
 
 ## Props
 
-| Prop name | Description | Type            | Values | Default    |
-| --------- | ----------- | --------------- | ------ | ---------- |
-| position  |             | string          | -      | 'topright' |
-| options   |             | object          | -      | {}         |
-| prefix    |             | string\|boolean | -      | null       |
+| Prop name | Description                                          | Type            | Values | Default    |
+| --------- | ---------------------------------------------------- | --------------- | ------ | ---------- |
+| position  |                                                      | string          | -      | 'topright' |
+| options   | Leaflet options to pass to the component constructor | object          | -      | {}         |
+| prefix    |                                                      | string\|boolean | -      | null       |
 
 ## Events
 

--- a/docs/components/LControlLayers.md
+++ b/docs/components/LControlLayers.md
@@ -64,15 +64,15 @@ export default {
 
 ## Props
 
-| Prop name      | Description | Type    | Values | Default    |
-| -------------- | ----------- | ------- | ------ | ---------- |
-| position       |             | string  | -      | 'topright' |
-| options        |             | object  | -      | {}         |
-| collapsed      |             | boolean | -      | true       |
-| autoZIndex     |             | boolean | -      | true       |
-| hideSingleBase |             | boolean | -      | false      |
-| sortLayers     |             | boolean | -      | false      |
-| sortFunction   |             | func    | -      | undefined  |
+| Prop name      | Description                                          | Type    | Values | Default    |
+| -------------- | ---------------------------------------------------- | ------- | ------ | ---------- |
+| position       |                                                      | string  | -      | 'topright' |
+| options        | Leaflet options to pass to the component constructor | object  | -      | {}         |
+| collapsed      |                                                      | boolean | -      | true       |
+| autoZIndex     |                                                      | boolean | -      | true       |
+| hideSingleBase |                                                      | boolean | -      | false      |
+| sortLayers     |                                                      | boolean | -      | false      |
+| sortFunction   |                                                      | func    | -      | undefined  |
 
 ## Events
 

--- a/docs/components/LControlScale.md
+++ b/docs/components/LControlScale.md
@@ -41,14 +41,14 @@ export default {
 
 ## Props
 
-| Prop name      | Description | Type    | Values | Default    |
-| -------------- | ----------- | ------- | ------ | ---------- |
-| position       |             | string  | -      | 'topright' |
-| options        |             | object  | -      | {}         |
-| maxWidth       |             | number  | -      | 100        |
-| metric         |             | boolean | -      | true       |
-| imperial       |             | boolean | -      | true       |
-| updateWhenIdle |             | boolean | -      | false      |
+| Prop name      | Description                                          | Type    | Values | Default    |
+| -------------- | ---------------------------------------------------- | ------- | ------ | ---------- |
+| position       |                                                      | string  | -      | 'topright' |
+| options        | Leaflet options to pass to the component constructor | object  | -      | {}         |
+| maxWidth       |                                                      | number  | -      | 100        |
+| metric         |                                                      | boolean | -      | true       |
+| imperial       |                                                      | boolean | -      | true       |
+| updateWhenIdle |                                                      | boolean | -      | false      |
 
 ## Events
 

--- a/docs/components/LControlZoom.md
+++ b/docs/components/LControlZoom.md
@@ -41,14 +41,14 @@ export default {
 
 ## Props
 
-| Prop name    | Description | Type   | Values | Default    |
-| ------------ | ----------- | ------ | ------ | ---------- |
-| position     |             | string | -      | 'topright' |
-| options      |             | object | -      | {}         |
-| zoomInText   |             | string | -      | '+'        |
-| zoomInTitle  |             | string | -      | 'Zoom in'  |
-| zoomOutText  |             | string | -      | '-'        |
-| zoomOutTitle |             | string | -      | 'Zoom out' |
+| Prop name    | Description                                          | Type   | Values | Default    |
+| ------------ | ---------------------------------------------------- | ------ | ------ | ---------- |
+| position     |                                                      | string | -      | 'topright' |
+| options      | Leaflet options to pass to the component constructor | object | -      | {}         |
+| zoomInText   |                                                      | string | -      | '+'        |
+| zoomInTitle  |                                                      | string | -      | 'Zoom in'  |
+| zoomOutText  |                                                      | string | -      | '-'        |
+| zoomOutTitle |                                                      | string | -      | 'Zoom out' |
 
 ## Events
 

--- a/docs/components/LFeatureGroup.md
+++ b/docs/components/LFeatureGroup.md
@@ -70,14 +70,14 @@ export default {
 
 ## Props
 
-| Prop name   | Description | Type    | Values | Default       |
-| ----------- | ----------- | ------- | ------ | ------------- |
-| pane        |             | string  | -      | 'overlayPane' |
-| attribution |             | string  | -      | null          |
-| name        |             | string  | -      | undefined     |
-| layerType   |             | string  | -      | undefined     |
-| visible     |             | boolean | -      | true          |
-| options     |             | object  | -      | {}            |
+| Prop name   | Description                                          | Type    | Values | Default       |
+| ----------- | ---------------------------------------------------- | ------- | ------ | ------------- |
+| pane        |                                                      | string  | -      | 'overlayPane' |
+| attribution |                                                      | string  | -      | null          |
+| name        |                                                      | string  | -      | undefined     |
+| layerType   |                                                      | string  | -      | undefined     |
+| visible     |                                                      | boolean | -      | true          |
+| options     | Leaflet options to pass to the component constructor | object  | -      | {}            |
 
 ## Events
 

--- a/docs/components/LGeoJson.md
+++ b/docs/components/LGeoJson.md
@@ -46,16 +46,16 @@ export default {
 
 ## Props
 
-| Prop name    | Description | Type          | Values | Default       |
-| ------------ | ----------- | ------------- | ------ | ------------- |
-| pane         |             | string        | -      | 'overlayPane' |
-| attribution  |             | string        | -      | null          |
-| name         |             | string        | -      | undefined     |
-| layerType    |             | string        | -      | undefined     |
-| visible      |             | boolean       | -      | true          |
-| options      |             | object        | -      | {}            |
-| geojson      |             | object\|array | -      | {}            |
-| optionsStyle |             | object\|func  | -      | null          |
+| Prop name    | Description                                          | Type          | Values | Default       |
+| ------------ | ---------------------------------------------------- | ------------- | ------ | ------------- |
+| pane         |                                                      | string        | -      | 'overlayPane' |
+| attribution  |                                                      | string        | -      | null          |
+| name         |                                                      | string        | -      | undefined     |
+| layerType    |                                                      | string        | -      | undefined     |
+| visible      |                                                      | boolean       | -      | true          |
+| options      | Leaflet options to pass to the component constructor | object        | -      | {}            |
+| geojson      |                                                      | object\|array | -      | {}            |
+| optionsStyle |                                                      | object\|func  | -      | null          |
 
 ## Events
 

--- a/docs/components/LGridLayer.md
+++ b/docs/components/LGridLayer.md
@@ -54,19 +54,19 @@ export default {
 
 ## Props
 
-| Prop name     | Description | Type    | Values | Default    |
-| ------------- | ----------- | ------- | ------ | ---------- |
-| pane          |             | string  | -      | 'tilePane' |
-| attribution   |             | string  | -      | null       |
-| name          |             | string  | -      | undefined  |
-| layerType     |             | string  | -      | undefined  |
-| visible       |             | boolean | -      | true       |
-| opacity       |             | number  | -      | 1.0        |
-| zIndex        |             | number  | -      | 1          |
-| tileSize      |             | number  | -      | 256        |
-| noWrap        |             | boolean | -      | false      |
-| options       |             | object  | -      | {}         |
-| tileComponent |             | object  | -      |            |
+| Prop name     | Description                                          | Type    | Values | Default    |
+| ------------- | ---------------------------------------------------- | ------- | ------ | ---------- |
+| pane          |                                                      | string  | -      | 'tilePane' |
+| attribution   |                                                      | string  | -      | null       |
+| name          |                                                      | string  | -      | undefined  |
+| layerType     |                                                      | string  | -      | undefined  |
+| visible       |                                                      | boolean | -      | true       |
+| opacity       |                                                      | number  | -      | 1.0        |
+| zIndex        |                                                      | number  | -      | 1          |
+| tileSize      |                                                      | number  | -      | 256        |
+| noWrap        |                                                      | boolean | -      | false      |
+| options       | Leaflet options to pass to the component constructor | object  | -      | {}         |
+| tileComponent |                                                      | object  | -      |            |
 
 ## Events
 

--- a/docs/components/LImageOverlay.md
+++ b/docs/components/LImageOverlay.md
@@ -50,24 +50,24 @@ export default {
 
 ## Props
 
-| Prop name           | Description | Type    | Values | Default       |
-| ------------------- | ----------- | ------- | ------ | ------------- |
-| pane                |             | string  | -      | 'overlayPane' |
-| attribution         |             | string  | -      | null          |
-| name                |             | string  | -      | undefined     |
-| layerType           |             | string  | -      | undefined     |
-| visible             |             | boolean | -      | true          |
-| interactive         |             | boolean | -      | false         |
-| bubblingMouseEvents |             | boolean | -      | true          |
-| url                 |             | string  | -      |               |
-| bounds              |             |         | -      |               |
-| opacity             |             | number  | -      | 1.0           |
-| alt                 |             | string  | -      | ''            |
-| crossOrigin         |             | boolean | -      | false         |
-| errorOverlayUrl     |             | string  | -      | ''            |
-| zIndex              |             | number  | -      | 1             |
-| className           |             | string  | -      | ''            |
-| options             |             | object  | -      | {}            |
+| Prop name           | Description                                          | Type    | Values | Default       |
+| ------------------- | ---------------------------------------------------- | ------- | ------ | ------------- |
+| pane                |                                                      | string  | -      | 'overlayPane' |
+| attribution         |                                                      | string  | -      | null          |
+| name                |                                                      | string  | -      | undefined     |
+| layerType           |                                                      | string  | -      | undefined     |
+| visible             |                                                      | boolean | -      | true          |
+| interactive         |                                                      | boolean | -      | false         |
+| bubblingMouseEvents |                                                      | boolean | -      | true          |
+| url                 |                                                      | string  | -      |               |
+| bounds              |                                                      |         | -      |               |
+| opacity             |                                                      | number  | -      | 1.0           |
+| alt                 |                                                      | string  | -      | ''            |
+| crossOrigin         |                                                      | boolean | -      | false         |
+| errorOverlayUrl     |                                                      | string  | -      | ''            |
+| zIndex              |                                                      | number  | -      | 1             |
+| className           |                                                      | string  | -      | ''            |
+| options             | Leaflet options to pass to the component constructor | object  | -      | {}            |
 
 ## Events
 

--- a/docs/components/LLayerGroup.md
+++ b/docs/components/LLayerGroup.md
@@ -70,14 +70,14 @@ export default {
 
 ## Props
 
-| Prop name   | Description | Type    | Values | Default       |
-| ----------- | ----------- | ------- | ------ | ------------- |
-| pane        |             | string  | -      | 'overlayPane' |
-| attribution |             | string  | -      | null          |
-| name        |             | string  | -      | undefined     |
-| layerType   |             | string  | -      | undefined     |
-| visible     |             | boolean | -      | true          |
-| options     |             | object  | -      | {}            |
+| Prop name   | Description                                          | Type    | Values | Default       |
+| ----------- | ---------------------------------------------------- | ------- | ------ | ------------- |
+| pane        |                                                      | string  | -      | 'overlayPane' |
+| attribution |                                                      | string  | -      | null          |
+| name        |                                                      | string  | -      | undefined     |
+| layerType   |                                                      | string  | -      | undefined     |
+| visible     |                                                      | boolean | -      | true          |
+| options     | Leaflet options to pass to the component constructor | object  | -      | {}            |
 
 ## Events
 

--- a/docs/components/LMap.md
+++ b/docs/components/LMap.md
@@ -70,30 +70,30 @@ export default {
 
 ## Props
 
-| Prop name              | Description                                    | Type          | Values         | Default            |
-| ---------------------- | ---------------------------------------------- | ------------- | -------------- | ------------------ |
-| options                |                                                | object        | -              | {}                 |
-| center                 | The center of the map, supports .sync modifier | object\|array | -              | () => [0, 0]       |
-| bounds                 | The bounds of the map, supports .sync modifier | array\|object | -              | null               |
-| maxBounds              | The max bounds of the map                      | array\|object | -              | null               |
-| zoom                   | The zoom of the map, supports .sync modifier   | number        | -              | 0                  |
-| minZoom                | The minZoom of the map                         | number        | -              | null               |
-| maxZoom                | The maxZoom of the map                         | number        | -              | null               |
-| paddingBottomRight     | The paddingBottomRight of the map              | array         | -              | null               |
-| paddingTopLeft         | The paddingTopLeft of the map                  | array         | -              | null               |
-| padding                | The padding of the map                         | array         | -              | null               |
-| worldCopyJump          | The worldCopyJump option for the map           | boolean       | -              | false              |
-| crs                    | The crs option for the map                     | object        | `CRS.EPSG3857` | () => CRS.EPSG3857 |
-| maxBoundsViscosity     |                                                | number        | -              | null               |
-| inertia                |                                                | boolean       | -              | null               |
-| inertiaDeceleration    |                                                | number        | -              | null               |
-| inertiaMaxSpeed        |                                                | number        | -              | null               |
-| easeLinearity          |                                                | number        | -              | null               |
-| zoomAnimation          |                                                | boolean       | -              | null               |
-| zoomAnimationThreshold |                                                | number        | -              | null               |
-| fadeAnimation          |                                                | boolean       | -              | null               |
-| markerZoomAnimation    |                                                | boolean       | -              | null               |
-| noBlockingAnimations   |                                                | boolean       | -              | false              |
+| Prop name              | Description                                          | Type          | Values         | Default            |
+| ---------------------- | ---------------------------------------------------- | ------------- | -------------- | ------------------ |
+| options                | Leaflet options to pass to the component constructor | object        | -              | {}                 |
+| center                 | The center of the map, supports .sync modifier       | object\|array | -              | () => [0, 0]       |
+| bounds                 | The bounds of the map, supports .sync modifier       | array\|object | -              | null               |
+| maxBounds              | The max bounds of the map                            | array\|object | -              | null               |
+| zoom                   | The zoom of the map, supports .sync modifier         | number        | -              | 0                  |
+| minZoom                | The minZoom of the map                               | number        | -              | null               |
+| maxZoom                | The maxZoom of the map                               | number        | -              | null               |
+| paddingBottomRight     | The paddingBottomRight of the map                    | array         | -              | null               |
+| paddingTopLeft         | The paddingTopLeft of the map                        | array         | -              | null               |
+| padding                | The padding of the map                               | array         | -              | null               |
+| worldCopyJump          | The worldCopyJump option for the map                 | boolean       | -              | false              |
+| crs                    | The crs option for the map                           | object        | `CRS.EPSG3857` | () => CRS.EPSG3857 |
+| maxBoundsViscosity     |                                                      | number        | -              | null               |
+| inertia                |                                                      | boolean       | -              | null               |
+| inertiaDeceleration    |                                                      | number        | -              | null               |
+| inertiaMaxSpeed        |                                                      | number        | -              | null               |
+| easeLinearity          |                                                      | number        | -              | null               |
+| zoomAnimation          |                                                      | boolean       | -              | null               |
+| zoomAnimationThreshold |                                                      | number        | -              | null               |
+| fadeAnimation          |                                                      | boolean       | -              | null               |
+| markerZoomAnimation    |                                                      | boolean       | -              | null               |
+| noBlockingAnimations   |                                                      | boolean       | -              | false              |
 
 ## Events
 

--- a/docs/components/LMarker.md
+++ b/docs/components/LMarker.md
@@ -42,18 +42,18 @@ export default {
 
 ## Props
 
-| Prop name    | Description | Type          | Values | Default                  |
-| ------------ | ----------- | ------------- | ------ | ------------------------ |
-| pane         |             | string        | -      | 'markerPane'             |
-| attribution  |             | string        | -      | null                     |
-| name         |             | string        | -      | undefined                |
-| layerType    |             | string        | -      | undefined                |
-| visible      |             | boolean       | -      | true                     |
-| options      |             | object        | -      | {}                       |
-| draggable    |             | boolean       | -      | false                    |
-| latLng       |             | object\|array | -      | null                     |
-| icon         |             | object        | -      | () => new Icon.Default() |
-| zIndexOffset |             | number        | -      | null                     |
+| Prop name    | Description                                          | Type          | Values | Default                  |
+| ------------ | ---------------------------------------------------- | ------------- | ------ | ------------------------ |
+| pane         |                                                      | string        | -      | 'markerPane'             |
+| attribution  |                                                      | string        | -      | null                     |
+| name         |                                                      | string        | -      | undefined                |
+| layerType    |                                                      | string        | -      | undefined                |
+| visible      |                                                      | boolean       | -      | true                     |
+| options      | Leaflet options to pass to the component constructor | object        | -      | {}                       |
+| draggable    |                                                      | boolean       | -      | false                    |
+| latLng       |                                                      | object\|array | -      | null                     |
+| icon         |                                                      | object        | -      | () => new Icon.Default() |
+| zIndexOffset |                                                      | number        | -      | null                     |
 
 ## Events
 

--- a/docs/components/LPolygon.md
+++ b/docs/components/LPolygon.md
@@ -45,33 +45,33 @@ export default {
 
 ## Props
 
-| Prop name           | Description | Type    | Values | Default       |
-| ------------------- | ----------- | ------- | ------ | ------------- |
-| pane                |             | string  | -      | 'overlayPane' |
-| attribution         |             | string  | -      | null          |
-| name                |             | string  | -      | undefined     |
-| layerType           |             | string  | -      | undefined     |
-| visible             |             | boolean | -      | true          |
-| interactive         |             | boolean | -      | true          |
-| bubblingMouseEvents |             | boolean | -      | true          |
-| lStyle              |             | object  | -      | null          |
-| stroke              |             | boolean | -      | true          |
-| color               |             | string  | -      | '#3388ff'     |
-| weight              |             | number  | -      | 3             |
-| opacity             |             | number  | -      | 1.0           |
-| lineCap             |             | string  | -      | 'round'       |
-| lineJoin            |             | string  | -      | 'round'       |
-| dashArray           |             | string  | -      | null          |
-| dashOffset          |             | string  | -      | null          |
-| fill                |             | boolean | -      | true          |
-| fillColor           |             | string  | -      | '#3388ff'     |
-| fillOpacity         |             | number  | -      | 0.2           |
-| fillRule            |             | string  | -      | 'evenodd'     |
-| className           |             | string  | -      | null          |
-| smoothFactor        |             | number  | -      | 1.0           |
-| noClip              |             | boolean | -      | false         |
-| options             |             | object  | -      | {}            |
-| latLngs             |             | array   | -      | () => []      |
+| Prop name           | Description                                          | Type    | Values | Default       |
+| ------------------- | ---------------------------------------------------- | ------- | ------ | ------------- |
+| pane                |                                                      | string  | -      | 'overlayPane' |
+| attribution         |                                                      | string  | -      | null          |
+| name                |                                                      | string  | -      | undefined     |
+| layerType           |                                                      | string  | -      | undefined     |
+| visible             |                                                      | boolean | -      | true          |
+| interactive         |                                                      | boolean | -      | true          |
+| bubblingMouseEvents |                                                      | boolean | -      | true          |
+| lStyle              |                                                      | object  | -      | null          |
+| stroke              |                                                      | boolean | -      | true          |
+| color               |                                                      | string  | -      | '#3388ff'     |
+| weight              |                                                      | number  | -      | 3             |
+| opacity             |                                                      | number  | -      | 1.0           |
+| lineCap             |                                                      | string  | -      | 'round'       |
+| lineJoin            |                                                      | string  | -      | 'round'       |
+| dashArray           |                                                      | string  | -      | null          |
+| dashOffset          |                                                      | string  | -      | null          |
+| fill                |                                                      | boolean | -      | true          |
+| fillColor           |                                                      | string  | -      | '#3388ff'     |
+| fillOpacity         |                                                      | number  | -      | 0.2           |
+| fillRule            |                                                      | string  | -      | 'evenodd'     |
+| className           |                                                      | string  | -      | null          |
+| smoothFactor        |                                                      | number  | -      | 1.0           |
+| noClip              |                                                      | boolean | -      | false         |
+| options             | Leaflet options to pass to the component constructor | object  | -      | {}            |
+| latLngs             |                                                      | array   | -      | () => []      |
 
 ## Events
 

--- a/docs/components/LPolyline.md
+++ b/docs/components/LPolyline.md
@@ -45,33 +45,33 @@ export default {
 
 ## Props
 
-| Prop name           | Description | Type    | Values | Default       |
-| ------------------- | ----------- | ------- | ------ | ------------- |
-| pane                |             | string  | -      | 'overlayPane' |
-| attribution         |             | string  | -      | null          |
-| name                |             | string  | -      | undefined     |
-| layerType           |             | string  | -      | undefined     |
-| visible             |             | boolean | -      | true          |
-| interactive         |             | boolean | -      | true          |
-| bubblingMouseEvents |             | boolean | -      | true          |
-| lStyle              |             | object  | -      | null          |
-| stroke              |             | boolean | -      | true          |
-| color               |             | string  | -      | '#3388ff'     |
-| weight              |             | number  | -      | 3             |
-| opacity             |             | number  | -      | 1.0           |
-| lineCap             |             | string  | -      | 'round'       |
-| lineJoin            |             | string  | -      | 'round'       |
-| dashArray           |             | string  | -      | null          |
-| dashOffset          |             | string  | -      | null          |
-| fill                |             | boolean | -      | false         |
-| fillColor           |             | string  | -      | '#3388ff'     |
-| fillOpacity         |             | number  | -      | 0.2           |
-| fillRule            |             | string  | -      | 'evenodd'     |
-| className           |             | string  | -      | null          |
-| smoothFactor        |             | number  | -      | 1.0           |
-| noClip              |             | boolean | -      | false         |
-| options             |             | object  | -      | {}            |
-| latLngs             |             | array   | -      | () => []      |
+| Prop name           | Description                                          | Type    | Values | Default       |
+| ------------------- | ---------------------------------------------------- | ------- | ------ | ------------- |
+| pane                |                                                      | string  | -      | 'overlayPane' |
+| attribution         |                                                      | string  | -      | null          |
+| name                |                                                      | string  | -      | undefined     |
+| layerType           |                                                      | string  | -      | undefined     |
+| visible             |                                                      | boolean | -      | true          |
+| interactive         |                                                      | boolean | -      | true          |
+| bubblingMouseEvents |                                                      | boolean | -      | true          |
+| lStyle              |                                                      | object  | -      | null          |
+| stroke              |                                                      | boolean | -      | true          |
+| color               |                                                      | string  | -      | '#3388ff'     |
+| weight              |                                                      | number  | -      | 3             |
+| opacity             |                                                      | number  | -      | 1.0           |
+| lineCap             |                                                      | string  | -      | 'round'       |
+| lineJoin            |                                                      | string  | -      | 'round'       |
+| dashArray           |                                                      | string  | -      | null          |
+| dashOffset          |                                                      | string  | -      | null          |
+| fill                |                                                      | boolean | -      | false         |
+| fillColor           |                                                      | string  | -      | '#3388ff'     |
+| fillOpacity         |                                                      | number  | -      | 0.2           |
+| fillRule            |                                                      | string  | -      | 'evenodd'     |
+| className           |                                                      | string  | -      | null          |
+| smoothFactor        |                                                      | number  | -      | 1.0           |
+| noClip              |                                                      | boolean | -      | false         |
+| options             | Leaflet options to pass to the component constructor | object  | -      | {}            |
+| latLngs             |                                                      | array   | -      | () => []      |
 
 ## Events
 

--- a/docs/components/LPopup.md
+++ b/docs/components/LPopup.md
@@ -49,11 +49,11 @@ export default {
 
 ## Props
 
-| Prop name | Description | Type          | Values | Default  |
-| --------- | ----------- | ------------- | ------ | -------- |
-| content   |             | string        | -      | null     |
-| options   |             | object        | -      | {}       |
-| latLng    |             | object\|array | -      | () => [] |
+| Prop name | Description                                          | Type          | Values | Default  |
+| --------- | ---------------------------------------------------- | ------------- | ------ | -------- |
+| content   |                                                      | string        | -      | null     |
+| options   | Leaflet options to pass to the component constructor | object        | -      | {}       |
+| latLng    |                                                      | object\|array | -      | () => [] |
 
 ## Events
 

--- a/docs/components/LRectangle.md
+++ b/docs/components/LRectangle.md
@@ -45,33 +45,33 @@ export default {
 
 ## Props
 
-| Prop name           | Description | Type    | Values | Default       |
-| ------------------- | ----------- | ------- | ------ | ------------- |
-| pane                |             | string  | -      | 'overlayPane' |
-| attribution         |             | string  | -      | null          |
-| name                |             | string  | -      | undefined     |
-| layerType           |             | string  | -      | undefined     |
-| visible             |             | boolean | -      | true          |
-| interactive         |             | boolean | -      | true          |
-| bubblingMouseEvents |             | boolean | -      | true          |
-| lStyle              |             | object  | -      | null          |
-| stroke              |             | boolean | -      | true          |
-| color               |             | string  | -      | '#3388ff'     |
-| weight              |             | number  | -      | 3             |
-| opacity             |             | number  | -      | 1.0           |
-| lineCap             |             | string  | -      | 'round'       |
-| lineJoin            |             | string  | -      | 'round'       |
-| dashArray           |             | string  | -      | null          |
-| dashOffset          |             | string  | -      | null          |
-| fill                |             | boolean | -      | true          |
-| fillColor           |             | string  | -      | '#3388ff'     |
-| fillOpacity         |             | number  | -      | 0.2           |
-| fillRule            |             | string  | -      | 'evenodd'     |
-| className           |             | string  | -      | null          |
-| smoothFactor        |             | number  | -      | 1.0           |
-| noClip              |             | boolean | -      | false         |
-| options             |             | object  | -      | {}            |
-| bounds              |             | array   | -      | () => []      |
+| Prop name           | Description                                          | Type    | Values | Default             |
+| ------------------- | ---------------------------------------------------- | ------- | ------ | ------------------- |
+| pane                |                                                      | string  | -      | 'overlayPane'       |
+| attribution         |                                                      | string  | -      | null                |
+| name                |                                                      | string  | -      | undefined           |
+| layerType           |                                                      | string  | -      | undefined           |
+| visible             |                                                      | boolean | -      | true                |
+| interactive         |                                                      | boolean | -      | true                |
+| bubblingMouseEvents |                                                      | boolean | -      | true                |
+| lStyle              |                                                      | object  | -      | null                |
+| stroke              |                                                      | boolean | -      | true                |
+| color               |                                                      | string  | -      | '#3388ff'           |
+| weight              |                                                      | number  | -      | 3                   |
+| opacity             |                                                      | number  | -      | 1.0                 |
+| lineCap             |                                                      | string  | -      | 'round'             |
+| lineJoin            |                                                      | string  | -      | 'round'             |
+| dashArray           |                                                      | string  | -      | null                |
+| dashOffset          |                                                      | string  | -      | null                |
+| fill                |                                                      | boolean | -      | true                |
+| fillColor           |                                                      | string  | -      | '#3388ff'           |
+| fillOpacity         |                                                      | number  | -      | 0.2                 |
+| fillRule            |                                                      | string  | -      | 'evenodd'           |
+| className           |                                                      | string  | -      | null                |
+| smoothFactor        |                                                      | number  | -      | 1.0                 |
+| noClip              |                                                      | boolean | -      | false               |
+| options             | Leaflet options to pass to the component constructor | object  | -      | {}                  |
+| bounds              |                                                      | func    | -      | () => [[0,0],[0,0]] |
 
 ## Events
 

--- a/docs/components/LTileLayer.md
+++ b/docs/components/LTileLayer.md
@@ -36,23 +36,23 @@ export default {
 
 ## Props
 
-| Prop name      | Description | Type    | Values | Default    |
-| -------------- | ----------- | ------- | ------ | ---------- |
-| pane           |             | string  | -      | 'tilePane' |
-| attribution    |             | string  | -      | null       |
-| name           |             | string  | -      | undefined  |
-| layerType      |             | string  | -      | undefined  |
-| visible        |             | boolean | -      | true       |
-| opacity        |             | number  | -      | 1.0        |
-| zIndex         |             | number  | -      | 1          |
-| tileSize       |             | number  | -      | 256        |
-| noWrap         |             | boolean | -      | false      |
-| tms            |             | boolean | -      | false      |
-| subdomains     |             | string  | -      | 'abc'      |
-| detectRetina   |             | boolean | -      | false      |
-| options        |             | object  | -      | {}         |
-| url            |             | string  | -      | null       |
-| tileLayerClass |             | func    | -      | tileLayer  |
+| Prop name      | Description                                          | Type          | Values | Default    |
+| -------------- | ---------------------------------------------------- | ------------- | ------ | ---------- |
+| pane           |                                                      | string        | -      | 'tilePane' |
+| attribution    |                                                      | string        | -      | null       |
+| name           |                                                      | string        | -      | undefined  |
+| layerType      |                                                      | string        | -      | undefined  |
+| visible        |                                                      | boolean       | -      | true       |
+| opacity        |                                                      | number        | -      | 1.0        |
+| zIndex         |                                                      | number        | -      | 1          |
+| tileSize       |                                                      | number        | -      | 256        |
+| noWrap         |                                                      | boolean       | -      | false      |
+| tms            |                                                      | boolean       | -      | false      |
+| subdomains     |                                                      | string\|array | -      | 'abc'      |
+| detectRetina   |                                                      | boolean       | -      | false      |
+| options        | Leaflet options to pass to the component constructor | object        | -      | {}         |
+| url            |                                                      | string        | -      | null       |
+| tileLayerClass |                                                      | func          | -      | tileLayer  |
 
 ## Events
 

--- a/docs/components/LTooltip.md
+++ b/docs/components/LTooltip.md
@@ -49,10 +49,10 @@ export default {
 
 ## Props
 
-| Prop name | Description | Type   | Values | Default |
-| --------- | ----------- | ------ | ------ | ------- |
-| content   |             | string | -      | null    |
-| options   |             | object | -      | {}      |
+| Prop name | Description                                          | Type   | Values | Default |
+| --------- | ---------------------------------------------------- | ------ | ------ | ------- |
+| content   |                                                      | string | -      | null    |
+| options   | Leaflet options to pass to the component constructor | object | -      | {}      |
 
 ## Events
 

--- a/docs/components/LWMSTileLayer.md
+++ b/docs/components/LWMSTileLayer.md
@@ -59,29 +59,29 @@ export default {
 
 ## Props
 
-| Prop name    | Description | Type    | Values | Default      |
-| ------------ | ----------- | ------- | ------ | ------------ |
-| pane         |             | string  | -      | 'tilePane'   |
-| attribution  |             | string  | -      | null         |
-| name         |             | string  | -      | undefined    |
-| layerType    |             | string  | -      | undefined    |
-| visible      |             | boolean | -      | true         |
-| opacity      |             | number  | -      | 1.0          |
-| zIndex       |             | number  | -      | 1            |
-| tileSize     |             | number  | -      | 256          |
-| noWrap       |             | boolean | -      | false        |
-| tms          |             | boolean | -      | false        |
-| subdomains   |             | string  | -      | 'abc'        |
-| detectRetina |             | boolean | -      | false        |
-| layers       |             | string  | -      | ''           |
-| styles       |             | string  | -      | ''           |
-| format       |             | string  | -      | 'image/jpeg' |
-| transparent  |             | boolean | -      |              |
-| version      |             | string  | -      | '1.1.1'      |
-| crs          |             | object  | -      | null         |
-| upperCase    |             | boolean | -      | false        |
-| options      |             | object  | -      | {}           |
-| baseUrl      |             | string  | -      | null         |
+| Prop name    | Description                                          | Type          | Values | Default      |
+| ------------ | ---------------------------------------------------- | ------------- | ------ | ------------ |
+| pane         |                                                      | string        | -      | 'tilePane'   |
+| attribution  |                                                      | string        | -      | null         |
+| name         |                                                      | string        | -      | undefined    |
+| layerType    |                                                      | string        | -      | undefined    |
+| visible      |                                                      | boolean       | -      | true         |
+| opacity      |                                                      | number        | -      | 1.0          |
+| zIndex       |                                                      | number        | -      | 1            |
+| tileSize     |                                                      | number        | -      | 256          |
+| noWrap       |                                                      | boolean       | -      | false        |
+| tms          |                                                      | boolean       | -      | false        |
+| subdomains   |                                                      | string\|array | -      | 'abc'        |
+| detectRetina |                                                      | boolean       | -      | false        |
+| layers       |                                                      | string        | -      | ''           |
+| styles       |                                                      | string        | -      | ''           |
+| format       |                                                      | string        | -      | 'image/jpeg' |
+| transparent  |                                                      | boolean       | -      |              |
+| version      |                                                      | string        | -      | '1.1.1'      |
+| crs          |                                                      | object        | -      | null         |
+| upperCase    |                                                      | boolean       | -      | false        |
+| options      | Leaflet options to pass to the component constructor | object        | -      | {}           |
+| baseUrl      |                                                      | string        | -      | null         |
 
 ## Events
 

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -17,8 +17,12 @@ It's possible to bind to them by simply writing `@leafletEventName`
 ::: tip
 Most components accept an `options` object, which will be passed to
 the constructor of the underlying Leaflet object. Use this to set any
-options that are not explicitly implemented as Vue `props` on the
-component.
+options that are not explicitly implemented as reactive Vue `props` on
+the component.
+
+**Note:** Leaflet often does not provide a mechanism for updating many
+of these options after creating a map element. For this reason, changes
+made to this `options` object are not reactive.
 :::
 
 ## Base

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -4,14 +4,21 @@ sidebarDepth: 2
 
 # Introduction
 
-Vue2Leaflet is a wrapper library for the mapping library [leaflet](https://leafletjs.com)
+Vue2Leaflet is a wrapper library for the mapping library [Leaflet](https://leafletjs.com)
 
-To easily encapsulate most of the functionality of leaflet a series of composable vue-components are provided.
+To easily encapsulate most of the functionality of Leaflet a series of composable vue-components are provided.
 
 ::: tip
 Most of our components do not emit events
-but **all** the components pass down listeners for leaflets events.
+but **all** the components pass down listeners for Leaflet's events.
 It's possible to bind to them by simply writing `@leafletEventName`
+:::
+
+::: tip
+Most components accept an `options` object, which will be passed to
+the constructor of the underlying Leaflet object. Use this to set any
+options that are not explicitly implemented as Vue `props` on the
+component.
 :::
 
 ## Base

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -12,6 +12,31 @@ To fix map rendering issues, it may help to [import the Leaflet stylesheet withi
 
 In most cases, though, it is Webpack messing with Leaflet marker icons' paths, resulting in warnings or even errors. You can alleviate that by either [unsetting/replacing the default paths](https://github.com/KoRiGaN/Vue2Leaflet/issues/96#issuecomment-341453050) ([alternate solution](https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-319569682)) or [using Webpack aliases](https://github.com/Leaflet/Leaflet/issues/4849#issuecomment-307436996).
 
+## How can I specify Leaflet options that aren't part of a component's `props`?
+
+Most components have an `options` prop that accepts an object to be passed to the underlying
+Leaflet constructor.
+
+```html
+<l-map :options="leafletMapOptions">
+  ...
+</l-map>
+```
+
+```javascript
+data () {
+  leafletMapOptions: {
+    closePopupOnClick: false,
+    doubleClickZoom: 'center',
+  }
+}
+```
+
+**Note:** Leaflet elements include many options that can only be set when the element
+is created. If Leaflet does not provide a method to change an option on an existing
+element after instantiation, that option most likely does not have a reactive Vue
+`props` entry, and should instead be set through the `options` object.
+
 ## How can I access the Leaflet map object?
 
 First add a ref to the map

--- a/src/mixins/Options.js
+++ b/src/mixins/Options.js
@@ -1,5 +1,8 @@
 export default {
   props: {
+    /**
+     * Leaflet options to pass to the component constructor
+     */
     options: {
       type: Object,
       default: () => ({})


### PR DESCRIPTION
The point was raised in #624 that there is no documentation indicating the rather important fact that all Leaflet options are available to be set on component creation through the `options` prop.

This updates the documentation for each component that uses the prop, and also adds some general descriptions of it to the components introduction and FAQ.