### PR TITLE
Make `_getIconUrl` optional in TS example

### DIFF
--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -134,7 +134,7 @@ For TypeScript, you will need to define `_getIconUrl` by hand as it is a private
 
 ```ts
 type D = Icon.Default & {
-  _getIconUrl: string;
+  _getIconUrl?: string;
 };
 
 delete (Icon.Default.prototype as D)._getIconUrl;


### PR DESCRIPTION
As per #627 , Typescript 4 now [requires operands for `delete` to be optional](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#operands-for-delete-must-be-optional). This means that the example in the quick-start documentation fails to compile as it currently stands.

The added `?` to make `_getIconUrl` optional (and therefore `delete`able) resolves this issue with TS4, and continues to function in TS3.