### PR TITLE
fix: cancel debounced functions in beforeDestroy

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -171,6 +171,10 @@ export default {
     },
   },
   beforeDestroy() {
+    if (this.debouncedMoveEndHandler) {
+      this.debouncedMoveEndHandler.cancel();
+    }
+
     if (this.mapObject) {
       this.mapObject.remove();
     }
@@ -201,7 +205,8 @@ export default {
     if (this.bounds) {
       this.mapObject.fitBounds(this.bounds);
     }
-    this.mapObject.on('moveend', debounce(this.moveEndHandler, 100));
+    this.debouncedMoveEndHandler = debounce(this.moveEndHandler, 100);
+    this.mapObject.on('moveend', this.debouncedMoveEndHandler);
     this.mapObject.on('overlayadd', this.overlayAddHandler);
     this.mapObject.on('overlayremove', this.overlayRemoveHandler);
     DomEvent.on(this.mapObject, this.$listeners);

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -46,6 +46,11 @@ export default {
       ready: false,
     };
   },
+  beforeDestroy() {
+    if (this.debouncedLatLngSync) {
+      this.debouncedLatLngSync.cancel();
+    }
+  },
   mounted() {
     const options = optionsMerger(
       {
@@ -58,7 +63,8 @@ export default {
     );
     this.mapObject = marker(this.latLng, options);
     DomEvent.on(this.mapObject, this.$listeners);
-    this.mapObject.on('move', debounce(this.latLngSync, 100));
+    this.debouncedLatLngSync = debounce(this.latLngSync, 100);
+    this.mapObject.on('move', this.debouncedLatLngSync);
     propsBinder(this, this.mapObject, this.$options.props);
     this.parentContainer = findRealParent(this.$parent);
     this.parentContainer.addLayer(this, !this.visible);

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -3,7 +3,7 @@ import { setOptions } from 'leaflet';
 export const debounce = (fn, time) => {
   let timeout;
 
-  return function(...args) {
+  const debouncedFunction = function(...args) {
     const context = this;
     if (timeout) {
       clearTimeout(timeout);
@@ -13,6 +13,14 @@ export const debounce = (fn, time) => {
       timeout = null;
     }, time);
   };
+
+  debouncedFunction.cancel = function() {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  };
+
+  return debouncedFunction;
 };
 
 export const capitalizeFirstLetter = string => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The debounced functions aren't canceled in `beforeDestroy` causing them to try to access values after they've been destroyed

Fixes https://github.com/vue-leaflet/Vue2Leaflet/issues/613

**How did you fix it?**

Cancel the debounced functions in `beforeDestroy`