### PR TITLE
Resolve 642: Add opacity as a reactive LMarker prop

### DIFF
--- a/docs/components/LMarker.md
+++ b/docs/components/LMarker.md
@@ -53,6 +53,7 @@ export default {
 | draggable    |                                                      | boolean       | -      | false                    |
 | latLng       |                                                      | object\|array | -      | null                     |
 | icon         |                                                      | object        | -      | () => new Icon.Default() |
+| opacity      |                                                      | number        | -      | 1.0                      |
 | zIndexOffset |                                                      | number        | -      | null                     |
 
 ## Events

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -35,6 +35,11 @@ export default {
       custom: false,
       default: () => new Icon.Default(),
     },
+    opacity: {
+      type: Number,
+      custon: false,
+      default: 1.0,
+    },
     zIndexOffset: {
       type: Number,
       custom: false,
@@ -58,6 +63,7 @@ export default {
         icon: this.icon,
         zIndexOffset: this.zIndexOffset,
         draggable: this.draggable,
+        opacity: this.opacity,
       },
       this
     );

--- a/tests/unit/components/LMarker.spec.js
+++ b/tests/unit/components/LMarker.spec.js
@@ -72,4 +72,18 @@ describe('component: LMarker.vue', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.mapObject.getLatLng().equals(initLatlng)).toBe(true);
   });
+
+  test('LMarkver.vue "opacity" prop defaults to 1 and updates mapObject opacity option', async () => {
+    const { wrapper } = getWrapperWithMap(LMarker, {
+      latLng: [0, 0]
+    });
+    const markerObject = wrapper.vm.mapObject;
+
+    expect(markerObject.options.opacity).toBe(1);
+
+    wrapper.setProps({ opacity: 0.42 });
+    await wrapper.vm.$nextTick();
+
+    expect(markerObject.options.opacity).toBe(0.42);
+  });
 });


### PR DESCRIPTION
The opacity of a Leaflet maker is not updated by `setOptions` but by the specific method `setOpacity`. Right now, the opacity of a marker icon can be set initially via `<l-marker :options="{ opacity }"/>`, but subsequent updates to `this.opacity` don't alter the state of the marker.

This PR adds `opacity` as a prop on the `LMarker` component, which calls `setOpacity` (via the standard `propsBinder`) whenever the value of the prop changes.