### PR TITLE
Fix typo in opacity prop definition

### DIFF
--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -37,7 +37,7 @@ export default {
     },
     opacity: {
       type: Number,
-      custon: false,
+      custom: false,
       default: 1.0,
     },
     zIndexOffset: {


### PR DESCRIPTION
Resolve #646 by fixing the small typo in the props, `custon` -> `custom`.