### PR TITLE
Fix bug in LIcon not properly referencing parent container's map object

### DIFF
--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -92,8 +92,10 @@ export default {
 
   mounted() {
     this.parentContainer = findRealParent(this.$parent);
-
-    propsBinder(this, this.$parent.mapObject, this.$options.props);
+    if (!this.parentContainer) {
+      throw new Error('No parent container with mapObject found for LIcon');
+    }
+    propsBinder(this, this.parentContainer.mapObject, this.$options.props);
 
     this.observer = new MutationObserver(() => {
       this.scheduleHtmlSwap();


### PR DESCRIPTION
The current code as is only works if the Licon is directly beneath another Vue2Leafleft component.
This fix addresses using the correct real parent already determined but not used when binding props upon mounting of the component.