### PR TITLE
Use same addLayer call in LLayerGroup as other components

### DIFF
--- a/src/components/LLayerGroup.vue
+++ b/src/components/LLayerGroup.vue
@@ -27,9 +27,7 @@ export default {
     DomEvent.on(this.mapObject, this.$listeners);
     this.ready = true;
     this.parentContainer = findRealParent(this.$parent);
-    if (this.visible) {
-      this.parentContainer.addLayer(this);
-    }
+    this.parentContainer.addLayer(this, !this.visible);
     this.$nextTick(() => {
       /**
        * Triggers when the component is ready


### PR DESCRIPTION
This very simple fix brings the `LLayerGroup` component in line with all of the others, in terms of how it adds its layer to the parent container. Resolves #666.