### PR TITLE
Fix tile size prop type

### DIFF
--- a/docs/components/LGridLayer.md
+++ b/docs/components/LGridLayer.md
@@ -54,19 +54,19 @@ export default {
 
 ## Props
 
-| Prop name     | Description                                          | Type    | Values | Default    |
-| ------------- | ---------------------------------------------------- | ------- | ------ | ---------- |
-| pane          |                                                      | string  | -      | 'tilePane' |
-| attribution   |                                                      | string  | -      | null       |
-| name          |                                                      | string  | -      | undefined  |
-| layerType     |                                                      | string  | -      | undefined  |
-| visible       |                                                      | boolean | -      | true       |
-| opacity       |                                                      | number  | -      | 1.0        |
-| zIndex        |                                                      | number  | -      | 1          |
-| tileSize      |                                                      | number  | -      | 256        |
-| noWrap        |                                                      | boolean | -      | false      |
-| options       | Leaflet options to pass to the component constructor | object  | -      | {}         |
-| tileComponent |                                                      | object  | -      |            |
+| Prop name     | Description                                          | Type                  | Values | Default    |
+| ------------- | ---------------------------------------------------- | --------------------- | ------ | ---------- |
+| pane          |                                                      | string                | -      | 'tilePane' |
+| attribution   |                                                      | string                | -      | null       |
+| name          |                                                      | string                | -      | undefined  |
+| layerType     |                                                      | string                | -      | undefined  |
+| visible       |                                                      | boolean               | -      | true       |
+| opacity       |                                                      | number                | -      | 1.0        |
+| zIndex        |                                                      | number                | -      | 1          |
+| tileSize      |                                                      | number\|object\|array | -      | 256        |
+| noWrap        |                                                      | boolean               | -      | false      |
+| options       | Leaflet options to pass to the component constructor | object                | -      | {}         |
+| tileComponent |                                                      | object                | -      |            |
 
 ## Events
 

--- a/docs/components/LTileLayer.md
+++ b/docs/components/LTileLayer.md
@@ -36,23 +36,23 @@ export default {
 
 ## Props
 
-| Prop name      | Description                                          | Type          | Values | Default    |
-| -------------- | ---------------------------------------------------- | ------------- | ------ | ---------- |
-| pane           |                                                      | string        | -      | 'tilePane' |
-| attribution    |                                                      | string        | -      | null       |
-| name           |                                                      | string        | -      | undefined  |
-| layerType      |                                                      | string        | -      | undefined  |
-| visible        |                                                      | boolean       | -      | true       |
-| opacity        |                                                      | number        | -      | 1.0        |
-| zIndex         |                                                      | number        | -      | 1          |
-| tileSize       |                                                      | number        | -      | 256        |
-| noWrap         |                                                      | boolean       | -      | false      |
-| tms            |                                                      | boolean       | -      | false      |
-| subdomains     |                                                      | string\|array | -      | 'abc'      |
-| detectRetina   |                                                      | boolean       | -      | false      |
-| options        | Leaflet options to pass to the component constructor | object        | -      | {}         |
-| url            |                                                      | string        | -      | null       |
-| tileLayerClass |                                                      | func          | -      | tileLayer  |
+| Prop name      | Description                                          | Type           | Values | Default    |
+| -------------- | ---------------------------------------------------- | -------------- | ------ | ---------- |
+| pane           |                                                      | string         | -      | 'tilePane' |
+| attribution    |                                                      | string         | -      | null       |
+| name           |                                                      | string         | -      | undefined  |
+| layerType      |                                                      | string         | -      | undefined  |
+| visible        |                                                      | boolean        | -      | true       |
+| opacity        |                                                      | number         | -      | 1.0        |
+| zIndex         |                                                      | number         | -      | 1          |
+| tileSize       |                                                      | number\|object | -      | 256        |
+| noWrap         |                                                      | boolean        | -      | false      |
+| tms            |                                                      | boolean        | -      | false      |
+| subdomains     |                                                      | string\|array  | -      | 'abc'      |
+| detectRetina   |                                                      | boolean        | -      | false      |
+| options        | Leaflet options to pass to the component constructor | object         | -      | {}         |
+| url            |                                                      | string         | -      | null       |
+| tileLayerClass |                                                      | func           | -      | tileLayer  |
 
 ## Events
 

--- a/docs/components/LTileLayer.md
+++ b/docs/components/LTileLayer.md
@@ -36,23 +36,23 @@ export default {
 
 ## Props
 
-| Prop name      | Description                                          | Type           | Values | Default    |
-| -------------- | ---------------------------------------------------- | -------------- | ------ | ---------- |
-| pane           |                                                      | string         | -      | 'tilePane' |
-| attribution    |                                                      | string         | -      | null       |
-| name           |                                                      | string         | -      | undefined  |
-| layerType      |                                                      | string         | -      | undefined  |
-| visible        |                                                      | boolean        | -      | true       |
-| opacity        |                                                      | number         | -      | 1.0        |
-| zIndex         |                                                      | number         | -      | 1          |
-| tileSize       |                                                      | number\|object | -      | 256        |
-| noWrap         |                                                      | boolean        | -      | false      |
-| tms            |                                                      | boolean        | -      | false      |
-| subdomains     |                                                      | string\|array  | -      | 'abc'      |
-| detectRetina   |                                                      | boolean        | -      | false      |
-| options        | Leaflet options to pass to the component constructor | object         | -      | {}         |
-| url            |                                                      | string         | -      | null       |
-| tileLayerClass |                                                      | func           | -      | tileLayer  |
+| Prop name      | Description                                          | Type                  | Values | Default    |
+| -------------- | ---------------------------------------------------- | --------------------- | ------ | ---------- |
+| pane           |                                                      | string                | -      | 'tilePane' |
+| attribution    |                                                      | string                | -      | null       |
+| name           |                                                      | string                | -      | undefined  |
+| layerType      |                                                      | string                | -      | undefined  |
+| visible        |                                                      | boolean               | -      | true       |
+| opacity        |                                                      | number                | -      | 1.0        |
+| zIndex         |                                                      | number                | -      | 1          |
+| tileSize       |                                                      | number\|object\|array | -      | 256        |
+| noWrap         |                                                      | boolean               | -      | false      |
+| tms            |                                                      | boolean               | -      | false      |
+| subdomains     |                                                      | string\|array         | -      | 'abc'      |
+| detectRetina   |                                                      | boolean               | -      | false      |
+| options        | Leaflet options to pass to the component constructor | object                | -      | {}         |
+| url            |                                                      | string                | -      | null       |
+| tileLayerClass |                                                      | func                  | -      | tileLayer  |
 
 ## Events
 

--- a/docs/components/LWMSTileLayer.md
+++ b/docs/components/LWMSTileLayer.md
@@ -59,29 +59,29 @@ export default {
 
 ## Props
 
-| Prop name    | Description                                          | Type           | Values | Default      |
-| ------------ | ---------------------------------------------------- | -------------- | ------ | ------------ |
-| pane         |                                                      | string         | -      | 'tilePane'   |
-| attribution  |                                                      | string         | -      | null         |
-| name         |                                                      | string         | -      | undefined    |
-| layerType    |                                                      | string         | -      | undefined    |
-| visible      |                                                      | boolean        | -      | true         |
-| opacity      |                                                      | number         | -      | 1.0          |
-| zIndex       |                                                      | number         | -      | 1            |
-| tileSize     |                                                      | number\|object | -      | 256          |
-| noWrap       |                                                      | boolean        | -      | false        |
-| tms          |                                                      | boolean        | -      | false        |
-| subdomains   |                                                      | string\|array  | -      | 'abc'        |
-| detectRetina |                                                      | boolean        | -      | false        |
-| layers       |                                                      | string         | -      | ''           |
-| styles       |                                                      | string         | -      | ''           |
-| format       |                                                      | string         | -      | 'image/jpeg' |
-| transparent  |                                                      | boolean        | -      |              |
-| version      |                                                      | string         | -      | '1.1.1'      |
-| crs          |                                                      | object         | -      | null         |
-| upperCase    |                                                      | boolean        | -      | false        |
-| options      | Leaflet options to pass to the component constructor | object         | -      | {}           |
-| baseUrl      |                                                      | string         | -      | null         |
+| Prop name    | Description                                          | Type                  | Values | Default      |
+| ------------ | ---------------------------------------------------- | --------------------- | ------ | ------------ |
+| pane         |                                                      | string                | -      | 'tilePane'   |
+| attribution  |                                                      | string                | -      | null         |
+| name         |                                                      | string                | -      | undefined    |
+| layerType    |                                                      | string                | -      | undefined    |
+| visible      |                                                      | boolean               | -      | true         |
+| opacity      |                                                      | number                | -      | 1.0          |
+| zIndex       |                                                      | number                | -      | 1            |
+| tileSize     |                                                      | number\|object\|array | -      | 256          |
+| noWrap       |                                                      | boolean               | -      | false        |
+| tms          |                                                      | boolean               | -      | false        |
+| subdomains   |                                                      | string\|array         | -      | 'abc'        |
+| detectRetina |                                                      | boolean               | -      | false        |
+| layers       |                                                      | string                | -      | ''           |
+| styles       |                                                      | string                | -      | ''           |
+| format       |                                                      | string                | -      | 'image/jpeg' |
+| transparent  |                                                      | boolean               | -      |              |
+| version      |                                                      | string                | -      | '1.1.1'      |
+| crs          |                                                      | object                | -      | null         |
+| upperCase    |                                                      | boolean               | -      | false        |
+| options      | Leaflet options to pass to the component constructor | object                | -      | {}           |
+| baseUrl      |                                                      | string                | -      | null         |
 
 ## Events
 

--- a/docs/components/LWMSTileLayer.md
+++ b/docs/components/LWMSTileLayer.md
@@ -59,29 +59,29 @@ export default {
 
 ## Props
 
-| Prop name    | Description                                          | Type          | Values | Default      |
-| ------------ | ---------------------------------------------------- | ------------- | ------ | ------------ |
-| pane         |                                                      | string        | -      | 'tilePane'   |
-| attribution  |                                                      | string        | -      | null         |
-| name         |                                                      | string        | -      | undefined    |
-| layerType    |                                                      | string        | -      | undefined    |
-| visible      |                                                      | boolean       | -      | true         |
-| opacity      |                                                      | number        | -      | 1.0          |
-| zIndex       |                                                      | number        | -      | 1            |
-| tileSize     |                                                      | number        | -      | 256          |
-| noWrap       |                                                      | boolean       | -      | false        |
-| tms          |                                                      | boolean       | -      | false        |
-| subdomains   |                                                      | string\|array | -      | 'abc'        |
-| detectRetina |                                                      | boolean       | -      | false        |
-| layers       |                                                      | string        | -      | ''           |
-| styles       |                                                      | string        | -      | ''           |
-| format       |                                                      | string        | -      | 'image/jpeg' |
-| transparent  |                                                      | boolean       | -      |              |
-| version      |                                                      | string        | -      | '1.1.1'      |
-| crs          |                                                      | object        | -      | null         |
-| upperCase    |                                                      | boolean       | -      | false        |
-| options      | Leaflet options to pass to the component constructor | object        | -      | {}           |
-| baseUrl      |                                                      | string        | -      | null         |
+| Prop name    | Description                                          | Type           | Values | Default      |
+| ------------ | ---------------------------------------------------- | -------------- | ------ | ------------ |
+| pane         |                                                      | string         | -      | 'tilePane'   |
+| attribution  |                                                      | string         | -      | null         |
+| name         |                                                      | string         | -      | undefined    |
+| layerType    |                                                      | string         | -      | undefined    |
+| visible      |                                                      | boolean        | -      | true         |
+| opacity      |                                                      | number         | -      | 1.0          |
+| zIndex       |                                                      | number         | -      | 1            |
+| tileSize     |                                                      | number\|object | -      | 256          |
+| noWrap       |                                                      | boolean        | -      | false        |
+| tms          |                                                      | boolean        | -      | false        |
+| subdomains   |                                                      | string\|array  | -      | 'abc'        |
+| detectRetina |                                                      | boolean        | -      | false        |
+| layers       |                                                      | string         | -      | ''           |
+| styles       |                                                      | string         | -      | ''           |
+| format       |                                                      | string         | -      | 'image/jpeg' |
+| transparent  |                                                      | boolean        | -      |              |
+| version      |                                                      | string         | -      | '1.1.1'      |
+| crs          |                                                      | object         | -      | null         |
+| upperCase    |                                                      | boolean        | -      | false        |
+| options      | Leaflet options to pass to the component constructor | object         | -      | {}           |
+| baseUrl      |                                                      | string         | -      | null         |
 
 ## Events
 

--- a/src/mixins/GridLayer.js
+++ b/src/mixins/GridLayer.js
@@ -17,7 +17,7 @@ export default {
       default: 1
     },
     tileSize: {
-      type: Number,
+      type: [Number, Object],
       default: 256
     },
     noWrap: {

--- a/src/mixins/GridLayer.js
+++ b/src/mixins/GridLayer.js
@@ -17,7 +17,7 @@ export default {
       default: 1
     },
     tileSize: {
-      type: [Number, Object],
+      type: [Number, Object, Array],
       default: 256
     },
     noWrap: {


### PR DESCRIPTION
`tileSize` option can be number if width and height are equal, or `L.point(width, height)` otherwise ([link](https://leafletjs.com/reference-1.7.1.html#gridlayer-tilesize)). This PR fixes prop type definition.