### PR TITLE
Move LImageOverlay url prop from mixin to component

### DIFF
--- a/docs/components/LImageOverlay.md
+++ b/docs/components/LImageOverlay.md
@@ -59,7 +59,6 @@ export default {
 | visible             |                                                      | boolean | -      | true          |
 | interactive         |                                                      | boolean | -      | false         |
 | bubblingMouseEvents |                                                      | boolean | -      | true          |
-| url                 |                                                      | string  | -      |               |
 | bounds              |                                                      |         | -      |               |
 | opacity             |                                                      | number  | -      | 1.0           |
 | alt                 |                                                      | string  | -      | ''            |
@@ -68,6 +67,7 @@ export default {
 | zIndex              |                                                      | number  | -      | 1             |
 | className           |                                                      | string  | -      | ''            |
 | options             | Leaflet options to pass to the component constructor | object  | -      | {}            |
+| url                 |                                                      | string  | -      | null          |
 
 ## Events
 

--- a/src/components/LImageOverlay.vue
+++ b/src/components/LImageOverlay.vue
@@ -10,6 +10,13 @@ import { imageOverlay, DomEvent } from 'leaflet';
 export default {
   name: 'LImageOverlay',
   mixins: [ImageOverlayMixin, Options],
+  props: {
+    url: {
+      type: String,
+      custom: true,
+      default: null
+    }
+  },
   mounted() {
     const options = optionsMerger(this.imageOverlayOptions, this);
     this.mapObject = imageOverlay(this.url, this.bounds, options);

--- a/src/mixins/ImageOverlay.js
+++ b/src/mixins/ImageOverlay.js
@@ -4,10 +4,6 @@ import InteractiveLayer from './InteractiveLayer';
 export default {
   mixins: [Layer, InteractiveLayer],
   props: {
-    url: {
-      type: String,
-      custom: true
-    },
     bounds: {
       custom: true
     },


### PR DESCRIPTION
This PR moves`LImageOverlay` `url` prop from mixin to a component so it doesn't end up in the  components that inherit its mixin (like [`LVideoOverlay`](https://github.com/vue-leaflet/Vue2Leaflet/pull/683) or [`LSVGOverlay`](https://github.com/vue-leaflet/Vue2Leaflet/pull/684))

If this PR is approved it should be merged before these two mentioned above because they depend on it.