### PR TITLE
Clear reference counter when position changed

### DIFF
--- a/src/components/LControlAttribution.vue
+++ b/src/components/LControlAttribution.vue
@@ -16,6 +16,13 @@ export default {
       default: null,
     },
   },
+  watch: {
+    position: {
+      handler() {
+        this.mapObject._attributions = {};
+      }
+    },
+  },
   mounted() {
     const options = optionsMerger(
       {


### PR DESCRIPTION
Fix #695.

Leaflet may assume the position of the attribution text as static.