### PR TITLE
[bug] Change 'upperCase' to 'uppercase' in mixins/TileLayerWMS

### DIFF
--- a/docs/components/LWMSTileLayer.md
+++ b/docs/components/LWMSTileLayer.md
@@ -84,7 +84,7 @@ export default {
 | transparent  |                                                      | boolean               | -      |              |
 | version      |                                                      | string                | -      | '1.1.1'      |
 | crs          |                                                      | object                | -      | null         |
-| upperCase    |                                                      | boolean               | -      | false        |
+| uppercase    |                                                      | boolean               | -      | false        |
 | options      | Leaflet options to pass to the component constructor | object                | -      | {}           |
 | baseUrl      |                                                      | string                | -      | null         |
 

--- a/src/mixins/TileLayerWMS.js
+++ b/src/mixins/TileLayerWMS.js
@@ -26,7 +26,7 @@ export default {
     crs: {
       default: null
     },
-    upperCase: {
+    uppercase: {
       type: Boolean,
       default: false
     }
@@ -40,7 +40,7 @@ export default {
       transparent: this.transparent,
       version: this.version,
       crs: this.crs,
-      upperCase: this.upperCase
+      uppercase: this.uppercase
     };
   }
 };


### PR DESCRIPTION
This fixes a minor bug in the LWMSTileLayer component. The 'uppercase' option is all lowercase in Leaflet (https://leafletjs.com/reference.html#tilelayer-wms)