### PR TITLE
Add minNativeZoom and maxNativeZoom props to LGridLayer

### DIFF
--- a/docs/components/LGridLayer.md
+++ b/docs/components/LGridLayer.md
@@ -67,6 +67,8 @@ export default {
 | zIndex        |                                                      | number                | -      | 1          |
 | tileSize      |                                                      | number\|object\|array | -      | 256        |
 | noWrap        |                                                      | boolean               | -      | false      |
+| minNativeZoom |                                                      | number                | -      | undefined  |
+| maxNativeZoom |                                                      | number                | -      | undefined  |
 | options       | Leaflet options to pass to the component constructor | object                | -      | {}         |
 | tileComponent |                                                      | object                | -      |            |
 

--- a/docs/components/LTileLayer.md
+++ b/docs/components/LTileLayer.md
@@ -49,6 +49,8 @@ export default {
 | zIndex         |                                                      | number                | -      | 1          |
 | tileSize       |                                                      | number\|object\|array | -      | 256        |
 | noWrap         |                                                      | boolean               | -      | false      |
+| minNativeZoom  |                                                      | number                | -      | undefined  |
+| maxNativeZoom  |                                                      | number                | -      | undefined  |
 | tms            |                                                      | boolean               | -      | false      |
 | subdomains     |                                                      | string\|array         | -      | 'abc'      |
 | detectRetina   |                                                      | boolean               | -      | false      |

--- a/docs/components/LWMSTileLayer.md
+++ b/docs/components/LWMSTileLayer.md
@@ -64,29 +64,31 @@ export default {
 
 ## Props
 
-| Prop name    | Description                                          | Type                  | Values | Default      |
-| ------------ | ---------------------------------------------------- | --------------------- | ------ | ------------ |
-| pane         |                                                      | string                | -      | 'tilePane'   |
-| attribution  |                                                      | string                | -      | null         |
-| name         |                                                      | string                | -      | undefined    |
-| layerType    |                                                      | string                | -      | undefined    |
-| visible      |                                                      | boolean               | -      | true         |
-| opacity      |                                                      | number                | -      | 1.0          |
-| zIndex       |                                                      | number                | -      | 1            |
-| tileSize     |                                                      | number\|object\|array | -      | 256          |
-| noWrap       |                                                      | boolean               | -      | false        |
-| tms          |                                                      | boolean               | -      | false        |
-| subdomains   |                                                      | string\|array         | -      | 'abc'        |
-| detectRetina |                                                      | boolean               | -      | false        |
-| layers       |                                                      | string                | -      | ''           |
-| styles       |                                                      | string                | -      | ''           |
-| format       |                                                      | string                | -      | 'image/jpeg' |
-| transparent  |                                                      | boolean               | -      |              |
-| version      |                                                      | string                | -      | '1.1.1'      |
-| crs          |                                                      | object                | -      | null         |
-| upperCase    |                                                      | boolean               | -      | false        |
-| options      | Leaflet options to pass to the component constructor | object                | -      | {}           |
-| baseUrl      |                                                      | string                | -      | null         |
+| Prop name     | Description                                          | Type                  | Values | Default      |
+| ------------- | ---------------------------------------------------- | --------------------- | ------ | ------------ |
+| pane          |                                                      | string                | -      | 'tilePane'   |
+| attribution   |                                                      | string                | -      | null         |
+| name          |                                                      | string                | -      | undefined    |
+| layerType     |                                                      | string                | -      | undefined    |
+| visible       |                                                      | boolean               | -      | true         |
+| opacity       |                                                      | number                | -      | 1.0          |
+| zIndex        |                                                      | number                | -      | 1            |
+| tileSize      |                                                      | number\|object\|array | -      | 256          |
+| noWrap        |                                                      | boolean               | -      | false        |
+| minNativeZoom |                                                      | number                | -      | undefined    |
+| maxNativeZoom |                                                      | number                | -      | undefined    |
+| tms           |                                                      | boolean               | -      | false        |
+| subdomains    |                                                      | string\|array         | -      | 'abc'        |
+| detectRetina  |                                                      | boolean               | -      | false        |
+| layers        |                                                      | string                | -      | ''           |
+| styles        |                                                      | string                | -      | ''           |
+| format        |                                                      | string                | -      | 'image/jpeg' |
+| transparent   |                                                      | boolean               | -      |              |
+| version       |                                                      | string                | -      | '1.1.1'      |
+| crs           |                                                      | object                | -      | null         |
+| upperCase     |                                                      | boolean               | -      | false        |
+| options       | Leaflet options to pass to the component constructor | object                | -      | {}           |
+| baseUrl       |                                                      | string                | -      | null         |
 
 ## Events
 

--- a/src/mixins/GridLayer.js
+++ b/src/mixins/GridLayer.js
@@ -5,34 +5,44 @@ export default {
   props: {
     pane: {
       type: String,
-      default: 'tilePane'
+      default: 'tilePane',
     },
     opacity: {
       type: Number,
       custom: false,
-      default: 1.0
+      default: 1.0,
     },
     zIndex: {
       type: Number,
-      default: 1
+      default: 1,
     },
     tileSize: {
       type: [Number, Object, Array],
-      default: 256
+      default: 256,
     },
     noWrap: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
+    minNativeZoom: {
+      type: Number,
+      default: undefined,
+    },
+    maxNativeZoom: {
+      type: Number,
+      default: undefined,
+    },
   },
-  mounted () {
+  mounted() {
     this.gridLayerOptions = {
       ...this.layerOptions,
       pane: this.pane,
       opacity: this.opacity,
       zIndex: this.zIndex,
       tileSize: this.tileSize,
-      noWrap: this.noWrap
+      noWrap: this.noWrap,
+      minNativeZoom: this.minNativeZoom,
+      maxNativeZoom: this.maxNativeZoom,
     };
-  }
+  },
 };


### PR DESCRIPTION
Add the following missing options for `LGridLayer` (and `LTileLayer` by inheritance):
- `minNativeZoom`
- `maxNativeZoom`

Those can be useful to make map tiles stretchable (e.g. set `maxNativeZoom` to `14` and `maxZoom` to `16`), see Leaflet documentation: https://leafletjs.com/reference.html#gridlayer-maxnativezoom

@all-contributors please add @guillaumejounel for code and plugin (https://github.com/guillaumejounel/vue2-leaflet-polygonfillpattern)