### PR TITLE
feat: add noMoveStart prop to LMap

### DIFF
--- a/docs/components/LMap.md
+++ b/docs/components/LMap.md
@@ -96,6 +96,7 @@ export default {
 | fadeAnimation          |                                                      | boolean       | -              | null               |
 | markerZoomAnimation    |                                                      | boolean       | -              | null               |
 | noBlockingAnimations   |                                                      | boolean       | -              | false              |
+| noMoveStartOnPanning   | The `noMoveStart` option passed to panning methods   | boolean       | -              | false              |
 
 ## Events
 

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -141,6 +141,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    noMoveStartOnPanning: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -156,6 +160,7 @@ export default {
     fitBoundsOptions() {
       const options = {
         animate: this.noBlockingAnimations ? false : null,
+        noMoveStart: this.noMoveStartOnPanning,
       };
       if (this.padding) {
         options.padding = this.padding;
@@ -277,6 +282,7 @@ export default {
       if (newVal === undefined || newVal === null) { return; }
       this.mapObject.setZoom(newVal, {
         animate: this.noBlockingAnimations ? false : null,
+        noMoveStart: this.noMoveStartOnPanning,
       });
       this.cacheMapView();
     },
@@ -290,6 +296,7 @@ export default {
         this.lastSetCenter = newCenter;
         this.mapObject.panTo(newCenter, {
           animate: this.noBlockingAnimations ? false : null,
+          noMoveStart: this.noMoveStartOnPanning,
         });
         this.cacheMapView(undefined, newCenter);
       }


### PR DESCRIPTION
I need to use the [`noMoveStart`](https://leafletjs.com/reference.html#pan-options-nomovestart) option from `leaflet` to avoid triggering `movestart` events when the map auto pans.

This PR only adds a new prop to `LMap.vue` to specify this option. I named it `noMoveStartOnPanning` because I think `noMoveStart` can be a confusing name (can be understood like "don't even fire the `moveStart` event which is obviously not the purpose of the prop).