### PR TITLE
Fix LImageOverlay bounds props

### DIFF
--- a/docs/components/LImageOverlay.md
+++ b/docs/components/LImageOverlay.md
@@ -50,25 +50,24 @@ export default {
 
 ## Props
 
-| Prop name           | Description                                          | Type    | Values | Default       |
-| ------------------- | ---------------------------------------------------- | ------- | ------ | ------------- |
-| pane                |                                                      | string  | -      | 'overlayPane' |
-| attribution         |                                                      | string  | -      | null          |
-| name                |                                                      | string  | -      | undefined     |
-| layerType           |                                                      | string  | -      | undefined     |
-| visible             |                                                      | boolean | -      | true          |
-| interactive         |                                                      | boolean | -      | false         |
-| bubblingMouseEvents |                                                      | boolean | -      | true          |
-| url                 |                                                      | string  | -      |               |
-| bounds              |                                                      |         | -      |               |
-| opacity             |                                                      | number  | -      | 1.0           |
-| alt                 |                                                      | string  | -      | ''            |
-| crossOrigin         |                                                      | boolean | -      | false         |
-| errorOverlayUrl     |                                                      | string  | -      | ''            |
-| zIndex              |                                                      | number  | -      | 1             |
-| className           |                                                      | string  | -      | ''            |
-| options             | Leaflet options to pass to the component constructor | object  | -      | {}            |
-
+| Prop name           | Description                                          | Type          | Values | Default       |
+| ------------------- | ---------------------------------------------------- | -------       | ------ | ------------- |
+| pane                |                                                      | string        | -      | 'overlayPane' |
+| attribution         |                                                      | string        | -      | null          |
+| name                |                                                      | string        | -      | undefined     |
+| layerType           |                                                      | string        | -      | undefined     |
+| visible             |                                                      | boolean       | -      | true          |
+| interactive         |                                                      | boolean       | -      | false         |
+| bubblingMouseEvents |                                                      | boolean       | -      | true          |
+| url                 |                                                      | string        | -      |               |
+| bounds              |                                                      | array\|object | -      | null          |
+| opacity             |                                                      | number        | -      | 1.0           |
+| alt                 |                                                      | string        | -      | ''            |
+| crossOrigin         |                                                      | boolean       | -      | false         |
+| errorOverlayUrl     |                                                      | string        | -      | ''            |
+| zIndex              |                                                      | number        | -      | 1             |
+| className           |                                                      | string        | -      | ''            |
+| options             | Leaflet options to pass to the component constructor | object        | -      | {}            |
 ## Events
 
 | Event name     | Type    | Description                                        |

--- a/src/mixins/ImageOverlay.js
+++ b/src/mixins/ImageOverlay.js
@@ -9,7 +9,9 @@ export default {
       custom: true
     },
     bounds: {
-      custom: true
+      type: [Object, Array],
+      custom: true,
+      default: null,
     },
     opacity: {
       type: Number,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -76,7 +76,7 @@ declare module "vue2-leaflet" {
      * @default null
      */
     bounds: L.LatLngBoundsExpression | null;
-     /**
+    /**
      * @default 1.0
      */
     opacity: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,10 +73,10 @@ declare module "vue2-leaflet" {
     // props
     url: string;
     /**
-     * @default true
+     * @default null
      */
-    bounds: boolean;
-    /**
+    bounds: L.LatLngBoundsExpression | null;
+     /**
      * @default 1.0
      */
     opacity: number;


### PR DESCRIPTION
I think `bounds` is expected to be `[number, number][]` like ` [[-26.5, -25], [1021.5, 1023]]`
https://vue2-leaflet.netlify.app/components/LImageOverlay.html

This PR fixes `boolean` to `L.LatLngBoundsExpression | null`.