### PR TITLE
Fix LTooltip options to reactive

### DIFF
--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -9,6 +9,13 @@ import { tooltip, DomEvent } from 'leaflet';
 export default {
   name: 'LTooltip',
   mixins: [Popper, Options],
+  props: {
+    options: {
+      type: Object,
+      custom: true,
+      default: () => ({}),
+    },
+  },
   mounted() {
     const options = optionsMerger(this.popperOptions, this);
     this.mapObject = tooltip(options);
@@ -37,6 +44,13 @@ export default {
         this.parentContainer.mapObject.unbindTooltip();
       }
     }
+  },
+  methods: {
+    setOptions(newVal) {
+      this.parentContainer.mapObject
+        .unbindTooltip()
+        .bindTooltip(this.mapObject, newVal);
+    },
   },
 };
 </script>


### PR DESCRIPTION
Related: https://github.com/vue-leaflet/Vue2Leaflet/issues/446
LTooltip options is not reactive, so I called `unbindTooltip()` and `bindTooltip()` when options are updated.

https://user-images.githubusercontent.com/22453562/184093911-3d6282df-c49a-4634-a12f-42964bc70751.mov
